### PR TITLE
Fix macOS regression with recent iOS changes

### DIFF
--- a/src/Veldrid.MetalBindings/MTLBlitCommandEncoder.cs
+++ b/src/Veldrid.MetalBindings/MTLBlitCommandEncoder.cs
@@ -64,7 +64,7 @@ namespace Veldrid.MetalBindings
             }
         }
 
-        [DllImport("@rpath/metal_mono_workaround.framework/metal_mono_workaround")]
+        [DllImport("@rpath/metal_mono_workaround.framework/metal_mono_workaround", EntryPoint = "copyFromBuffer")]
         private static extern void copyFromBuffer_iOS(
             IntPtr encoder,
             IntPtr sourceBuffer,

--- a/src/Veldrid.MetalBindings/MTLBlitCommandEncoder.cs
+++ b/src/Veldrid.MetalBindings/MTLBlitCommandEncoder.cs
@@ -29,25 +29,43 @@ namespace Veldrid.MetalBindings
             MTLTexture destinationTexture,
             UIntPtr destinationSlice,
             UIntPtr destinationLevel,
-            MTLOrigin destinationOrigin)
+            MTLOrigin destinationOrigin,
+            bool isMacOS)
         {
-            copyFromBuffer(
-                NativePtr,
-                sourceBuffer.NativePtr,
-                sourceOffset,
-                sourceBytesPerRow,
-                sourceBytesPerImage,
-                sourceSize,
-                destinationTexture.NativePtr,
-                destinationSlice,
-                destinationLevel,
-                destinationOrigin.x,
-                destinationOrigin.y,
-                destinationOrigin.z);
+            if (!isMacOS)
+            {
+                copyFromBuffer_iOS(
+                    NativePtr,
+                    sourceBuffer.NativePtr,
+                    sourceOffset,
+                    sourceBytesPerRow,
+                    sourceBytesPerImage,
+                    sourceSize,
+                    destinationTexture.NativePtr,
+                    destinationSlice,
+                    destinationLevel,
+                    destinationOrigin.x,
+                    destinationOrigin.y,
+                    destinationOrigin.z);
+            }
+            else
+            {
+                objc_msgSend(NativePtr,
+                    sel_copyFromBuffer1,
+                    sourceBuffer.NativePtr,
+                    sourceOffset,
+                    sourceBytesPerRow,
+                    sourceBytesPerImage,
+                    sourceSize,
+                    destinationTexture.NativePtr,
+                    destinationSlice,
+                    destinationLevel,
+                    destinationOrigin);
+            }
         }
 
         [DllImport("@rpath/metal_mono_workaround.framework/metal_mono_workaround")]
-        private static extern void copyFromBuffer(
+        private static extern void copyFromBuffer_iOS(
             IntPtr encoder,
             IntPtr sourceBuffer,
             UIntPtr sourceOffset,

--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -451,7 +451,8 @@ namespace Veldrid.MTL
                         dstTexture,
                         (UIntPtr)(dstBaseArrayLayer + layer),
                         (UIntPtr)dstMipLevel,
-                        new MTLOrigin(dstX, dstY, dstZ));
+                        new MTLOrigin(dstX, dstY, dstZ),
+                        _gd.MetalFeatures.IsMacOS);
                 }
             }
             else if (srcIsStaging && dstIsStaging)


### PR DESCRIPTION
Didn't take that into account. Rather than deploying another library for macOS platform, I've chosen to just stick to the original method for that platform instead, since it works correctly there.