### PR TITLE
Vulkan: Fix reference counting

### DIFF
--- a/src/Veldrid/Vk/VkCommandList.cs
+++ b/src/Veldrid/Vk/VkCommandList.cs
@@ -99,10 +99,6 @@ namespace Veldrid.Vk
         public void CommandBufferSubmitted(VkCommandBuffer cb)
         {
             RefCount.Increment();
-            foreach (ResourceRefCount rrc in _currentStagingInfo.Resources)
-            {
-                rrc.Increment();
-            }
 
             _submittedStagingInfos.Add(cb, _currentStagingInfo);
             _currentStagingInfo = null;
@@ -257,6 +253,7 @@ namespace Veldrid.Vk
         {
             PreDrawCommand();
             VkBuffer vkBuffer = Util.AssertSubtype<DeviceBuffer, VkBuffer>(indirectBuffer);
+            vkBuffer.RefCount.Increment();
             _currentStagingInfo.Resources.Add(vkBuffer.RefCount);
             vkCmdDrawIndirect(_cb, vkBuffer.DeviceBuffer, offset, drawCount, stride);
         }
@@ -265,6 +262,7 @@ namespace Veldrid.Vk
         {
             PreDrawCommand();
             VkBuffer vkBuffer = Util.AssertSubtype<DeviceBuffer, VkBuffer>(indirectBuffer);
+            vkBuffer.RefCount.Increment();
             _currentStagingInfo.Resources.Add(vkBuffer.RefCount);
             vkCmdDrawIndexedIndirect(_cb, vkBuffer.DeviceBuffer, offset, drawCount, stride);
         }
@@ -318,11 +316,8 @@ namespace Veldrid.Vk
                     }
 
                     // Increment ref count on first use of a set.
+                    vkSet.RefCount.Increment();
                     _currentStagingInfo.Resources.Add(vkSet.RefCount);
-                    for (int i = 0; i < vkSet.RefCounts.Count; i++)
-                    {
-                        _currentStagingInfo.Resources.Add(vkSet.RefCounts[i]);
-                    }
                 }
 
                 if (batchEnded)
@@ -397,6 +392,7 @@ namespace Veldrid.Vk
             PreDispatchCommand();
 
             VkBuffer vkBuffer = Util.AssertSubtype<DeviceBuffer, VkBuffer>(indirectBuffer);
+            vkBuffer.RefCount.Increment();
             _currentStagingInfo.Resources.Add(vkBuffer.RefCount);
             vkCmdDispatchIndirect(_cb, vkBuffer.DeviceBuffer, offset);
         }
@@ -409,8 +405,10 @@ namespace Veldrid.Vk
             }
 
             VkTexture vkSource = Util.AssertSubtype<Texture, VkTexture>(source);
+            vkSource.RefCount.Increment();
             _currentStagingInfo.Resources.Add(vkSource.RefCount);
             VkTexture vkDestination = Util.AssertSubtype<Texture, VkTexture>(destination);
+            vkDestination.RefCount.Increment();
             _currentStagingInfo.Resources.Add(vkDestination.RefCount);
             VkImageAspectFlags aspectFlags = ((source.Usage & TextureUsage.DepthStencil) == TextureUsage.DepthStencil)
                 ? VkImageAspectFlags.Depth | VkImageAspectFlags.Stencil
@@ -491,10 +489,12 @@ namespace Veldrid.Vk
             Util.EnsureArrayMinimumSize(ref _clearValues, clearValueCount + 1); // Leave an extra space for the depth value (tracked separately).
             Util.ClearArray(_validColorClearValues);
             Util.EnsureArrayMinimumSize(ref _validColorClearValues, clearValueCount);
+            vkFB.RefCount.Increment();
             _currentStagingInfo.Resources.Add(vkFB.RefCount);
 
             if (fb is VkSwapchainFramebuffer scFB)
             {
+                scFB.Swapchain.RefCount.Increment();
                 _currentStagingInfo.Resources.Add(scFB.Swapchain.RefCount);
             }
         }
@@ -623,6 +623,7 @@ namespace Veldrid.Vk
             Vulkan.VkBuffer deviceBuffer = vkBuffer.DeviceBuffer;
             ulong offset64 = offset;
             vkCmdBindVertexBuffers(_cb, index, 1, ref deviceBuffer, ref offset64);
+            vkBuffer.RefCount.Increment();
             _currentStagingInfo.Resources.Add(vkBuffer.RefCount);
         }
 
@@ -630,6 +631,7 @@ namespace Veldrid.Vk
         {
             VkBuffer vkBuffer = Util.AssertSubtype<DeviceBuffer, VkBuffer>(buffer);
             vkCmdBindIndexBuffer(_cb, vkBuffer.DeviceBuffer, offset, VkFormats.VdToVkIndexFormat(format));
+            vkBuffer.RefCount.Increment();
             _currentStagingInfo.Resources.Add(vkBuffer.RefCount);
         }
 
@@ -652,7 +654,7 @@ namespace Veldrid.Vk
                 vkCmdBindPipeline(_cb, VkPipelineBindPoint.Compute, vkPipeline.DevicePipeline);
                 _currentComputePipeline = vkPipeline;
             }
-
+            vkPipeline.RefCount.Increment();
             _currentStagingInfo.Resources.Add(vkPipeline.RefCount);
         }
 
@@ -742,8 +744,10 @@ namespace Veldrid.Vk
             EnsureNoRenderPass();
 
             VkBuffer srcVkBuffer = Util.AssertSubtype<DeviceBuffer, VkBuffer>(source);
+            srcVkBuffer.RefCount.Increment();
             _currentStagingInfo.Resources.Add(srcVkBuffer.RefCount);
             VkBuffer dstVkBuffer = Util.AssertSubtype<DeviceBuffer, VkBuffer>(destination);
+            dstVkBuffer.RefCount.Increment();
             _currentStagingInfo.Resources.Add(dstVkBuffer.RefCount);
 
             VkBufferCopy region = new VkBufferCopy
@@ -789,8 +793,10 @@ namespace Veldrid.Vk
                 width, height, depth, layerCount);
 
             VkTexture srcVkTexture = Util.AssertSubtype<Texture, VkTexture>(source);
+            srcVkTexture.RefCount.Increment();
             _currentStagingInfo.Resources.Add(srcVkTexture.RefCount);
             VkTexture dstVkTexture = Util.AssertSubtype<Texture, VkTexture>(destination);
+            dstVkTexture.RefCount.Increment();
             _currentStagingInfo.Resources.Add(dstVkTexture.RefCount);
         }
 
@@ -1096,6 +1102,7 @@ namespace Veldrid.Vk
         {
             EnsureNoRenderPass();
             VkTexture vkTex = Util.AssertSubtype<Texture, VkTexture>(texture);
+            vkTex.RefCount.Increment();
             _currentStagingInfo.Resources.Add(vkTex.RefCount);
 
             uint layerCount = vkTex.ArrayLayers;

--- a/src/Veldrid/Vk/VkResourceSet.cs
+++ b/src/Veldrid/Vk/VkResourceSet.cs
@@ -62,6 +62,7 @@ namespace Veldrid.Vk
                     bufferInfos[i].offset = range.Offset;
                     bufferInfos[i].range = range.SizeInBytes;
                     descriptorWrites[i].pBufferInfo = &bufferInfos[i];
+                    rangedVkBuffer.RefCount.Increment();
                     _refCounts.Add(rangedVkBuffer.RefCount);
                 }
                 else if (type == VkDescriptorType.SampledImage)
@@ -72,6 +73,7 @@ namespace Veldrid.Vk
                     imageInfos[i].imageLayout = VkImageLayout.ShaderReadOnlyOptimal;
                     descriptorWrites[i].pImageInfo = &imageInfos[i];
                     _sampledTextures.Add(Util.AssertSubtype<Texture, VkTexture>(texView.Target));
+                    vkTexView.RefCount.Increment();
                     _refCounts.Add(vkTexView.RefCount);
                 }
                 else if (type == VkDescriptorType.StorageImage)
@@ -82,6 +84,7 @@ namespace Veldrid.Vk
                     imageInfos[i].imageLayout = VkImageLayout.General;
                     descriptorWrites[i].pImageInfo = &imageInfos[i];
                     _storageImages.Add(Util.AssertSubtype<Texture, VkTexture>(texView.Target));
+                    vkTexView.RefCount.Increment();
                     _refCounts.Add(vkTexView.RefCount);
                 }
                 else if (type == VkDescriptorType.Sampler)
@@ -89,6 +92,7 @@ namespace Veldrid.Vk
                     VkSampler sampler = Util.AssertSubtype<BindableResource, VkSampler>(boundResources[i]);
                     imageInfos[i].sampler = sampler.DeviceSampler;
                     descriptorWrites[i].pImageInfo = &imageInfos[i];
+                    sampler.RefCount.Increment();
                     _refCounts.Add(sampler.RefCount);
                 }
             }
@@ -108,6 +112,9 @@ namespace Veldrid.Vk
 
         public override void Dispose()
         {
+            foreach (ResourceRefCount rrc in _refCounts) {
+                rrc.Decrement();
+            }
             RefCount.Decrement();
         }
 


### PR DESCRIPTION
There seems to be something really wrong with the reference counting happening in the vulkan code.

I found this while debugging the problems raised in https://github.com/ppy/osu/issues/23056 and with this patch applied I was able to load into the map specified.