### PR TITLE
Fix vkTexture being disposed early

### DIFF
--- a/src/Veldrid/Vk/VkCommandList.cs
+++ b/src/Veldrid/Vk/VkCommandList.cs
@@ -319,10 +319,6 @@ namespace Veldrid.Vk
 
                     // Increment ref count on first use of a set.
                     _currentStagingInfo.Resources.Add(vkSet.RefCount);
-                    for (int i = 0; i < vkSet.RefCounts.Count; i++)
-                    {
-                        _currentStagingInfo.Resources.Add(vkSet.RefCounts[i]);
-                    }
                 }
 
                 if (batchEnded)

--- a/src/Veldrid/Vk/VkResourceSet.cs
+++ b/src/Veldrid/Vk/VkResourceSet.cs
@@ -62,6 +62,7 @@ namespace Veldrid.Vk
                     bufferInfos[i].offset = range.Offset;
                     bufferInfos[i].range = range.SizeInBytes;
                     descriptorWrites[i].pBufferInfo = &bufferInfos[i];
+                    rangedVkBuffer.RefCount.Increment();
                     _refCounts.Add(rangedVkBuffer.RefCount);
                 }
                 else if (type == VkDescriptorType.SampledImage)
@@ -72,6 +73,7 @@ namespace Veldrid.Vk
                     imageInfos[i].imageLayout = VkImageLayout.ShaderReadOnlyOptimal;
                     descriptorWrites[i].pImageInfo = &imageInfos[i];
                     _sampledTextures.Add(Util.AssertSubtype<Texture, VkTexture>(texView.Target));
+                    vkTexView.RefCount.Increment();
                     _refCounts.Add(vkTexView.RefCount);
                 }
                 else if (type == VkDescriptorType.StorageImage)
@@ -82,6 +84,7 @@ namespace Veldrid.Vk
                     imageInfos[i].imageLayout = VkImageLayout.General;
                     descriptorWrites[i].pImageInfo = &imageInfos[i];
                     _storageImages.Add(Util.AssertSubtype<Texture, VkTexture>(texView.Target));
+                    vkTexView.RefCount.Increment();
                     _refCounts.Add(vkTexView.RefCount);
                 }
                 else if (type == VkDescriptorType.Sampler)
@@ -89,6 +92,7 @@ namespace Veldrid.Vk
                     VkSampler sampler = Util.AssertSubtype<BindableResource, VkSampler>(boundResources[i]);
                     imageInfos[i].sampler = sampler.DeviceSampler;
                     descriptorWrites[i].pImageInfo = &imageInfos[i];
+                    sampler.RefCount.Increment();
                     _refCounts.Add(sampler.RefCount);
                 }
             }
@@ -115,6 +119,10 @@ namespace Veldrid.Vk
         {
             if (!_destroyed)
             {
+                foreach (ResourceRefCount refCount in _refCounts)
+                {
+                    refCount.Decrement();
+                }
                 _destroyed = true;
                 _gd.DescriptorPoolManager.Free(_descriptorAllocationToken, _descriptorCounts);
             }


### PR DESCRIPTION
Unless the reference count is in incremented immediately there is a chance that a referenced buffer gets destroyed before use.

Related: https://github.com/ppy/osu/issues/23056