### PR TITLE
Fix depth texture being recreated unnecessarily on Metal

### DIFF
--- a/src/Veldrid/MTL/MTLSwapchainFramebuffer.cs
+++ b/src/Veldrid/MTL/MTLSwapchainFramebuffer.cs
@@ -66,7 +66,7 @@ namespace Veldrid.MTL
             _colorTexture = new MTLTexture(drawable, size, _colorFormat);
             _colorTargets = new[] { new FramebufferAttachment(_colorTexture, 0) };
 
-            if (_depthFormat.HasValue)
+            if (_depthFormat.HasValue && (size.width != _depthTexture?.Width || size.height != _depthTexture?.Height))
                 RecreateDepthTexture((uint)size.width, (uint)size.height);
         }
 


### PR DESCRIPTION
Oversight from https://github.com/mellinoe/veldrid/pull/493 that resulted in the depth texture being recreated every single frame despite having the same size.