### PR TITLE
Avoid encoding redundant Metal render/compute commands to reduce CPU time (rebased)

### DIFF
--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -22,8 +22,8 @@ namespace Veldrid.MTL
         private MTLBuffer _indexBuffer;
         private uint _ibOffset;
         private MTLIndexType _indexType;
+        private MTLPipeline _lastGraphicsPipeline;
         private new MTLPipeline _graphicsPipeline;
-        private bool _graphicsPipelineChanged;
         private new MTLPipeline _computePipeline;
         private bool _computePipelineChanged;
         private MTLViewport[] _viewports = Array.Empty<MTLViewport>();
@@ -174,22 +174,38 @@ namespace Veldrid.MTL
                     FlushScissorRects();
                     _scissorRectsChanged = false;
                 }
-                if (_graphicsPipelineChanged)
-                {
-                    Debug.Assert(_graphicsPipeline != null);
+
+                Debug.Assert(_graphicsPipeline != null);
+
+                if (_graphicsPipeline.RenderPipelineState.NativePtr != _lastGraphicsPipeline?.RenderPipelineState.NativePtr)
                     _rce.setRenderPipelineState(_graphicsPipeline.RenderPipelineState);
+
+                if (_graphicsPipeline.CullMode != _lastGraphicsPipeline?.CullMode)
                     _rce.setCullMode(_graphicsPipeline.CullMode);
+
+                if (_graphicsPipeline.FrontFace != _lastGraphicsPipeline?.FrontFace)
                     _rce.setFrontFacing(_graphicsPipeline.FrontFace);
+
+                if (_graphicsPipeline.FillMode != _lastGraphicsPipeline?.FillMode)
                     _rce.setTriangleFillMode(_graphicsPipeline.FillMode);
-                    RgbaFloat blendColor = _graphicsPipeline.BlendColor;
+
+                RgbaFloat blendColor = _graphicsPipeline.BlendColor;
+                if (blendColor != _lastGraphicsPipeline?.BlendColor)
                     _rce.setBlendColor(blendColor.R, blendColor.G, blendColor.B, blendColor.A);
-                    if (_framebuffer.DepthTarget != null)
-                    {
+
+                if (_framebuffer.DepthTarget != null)
+                {
+                    if (_graphicsPipeline.DepthStencilState.NativePtr != _lastGraphicsPipeline?.DepthStencilState.NativePtr)
                         _rce.setDepthStencilState(_graphicsPipeline.DepthStencilState);
+
+                    if (_graphicsPipeline.DepthClipMode != _lastGraphicsPipeline?.DepthClipMode)
                         _rce.setDepthClipMode(_graphicsPipeline.DepthClipMode);
+
+                    if (_graphicsPipeline.StencilReference != _lastGraphicsPipeline?.StencilReference)
                         _rce.setStencilReferenceValue(_graphicsPipeline.StencilReference);
-                    }
                 }
+
+                _lastGraphicsPipeline = _graphicsPipeline;
 
                 for (uint i = 0; i < _graphicsResourceSetCount; i++)
                 {
@@ -305,8 +321,6 @@ namespace Veldrid.MTL
                 Util.EnsureArrayMinimumSize(ref _vbOffsets, _vertexBufferCount);
                 Util.EnsureArrayMinimumSize(ref _vertexBuffersActive, _vertexBufferCount);
                 Util.ClearArray(_vertexBuffersActive);
-
-                _graphicsPipelineChanged = true;
             }
         }
 
@@ -1055,8 +1069,10 @@ namespace Veldrid.MTL
             _rce.endEncoding();
             ObjectiveCRuntime.release(_rce.NativePtr);
             _rce = default(MTLRenderCommandEncoder);
-            _graphicsPipelineChanged = true;
+
+            _lastGraphicsPipeline = null;
             Util.ClearArray(_graphicsResourceSetsActive);
+
             _viewportsChanged = true;
             _scissorRectsChanged = true;
         }

--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -227,6 +227,7 @@ namespace Veldrid.MTL
                             _vertexBuffers[i].DeviceBuffer,
                             (UIntPtr)_vbOffsets[i],
                             index);
+                        _vertexBuffersActive[i] = true;
                     }
                 }
                 return true;
@@ -1118,6 +1119,7 @@ namespace Veldrid.MTL
             _boundFragmentTextures.Clear();
             _boundFragmentSamplers.Clear();
             Util.ClearArray(_graphicsResourceSetsActive);
+            Util.ClearArray(_vertexBuffersActive);
 
             _viewportsChanged = true;
             _scissorRectsChanged = true;

--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -899,13 +899,23 @@ namespace Veldrid.MTL
             }
         }
 
+        private readonly Dictionary<UIntPtr, DeviceBufferRange> _boundVertexBuffers = new Dictionary<UIntPtr, DeviceBufferRange>();
+        private readonly Dictionary<UIntPtr, DeviceBufferRange> _boundFragmentBuffers = new Dictionary<UIntPtr, DeviceBufferRange>();
+        private readonly Dictionary<UIntPtr, DeviceBufferRange> _boundComputeBuffers = new Dictionary<UIntPtr, DeviceBufferRange>();
+
         private void BindBuffer(DeviceBufferRange range, uint set, uint slot, ShaderStages stages)
         {
             MTLBuffer mtlBuffer = Util.AssertSubtype<DeviceBuffer, MTLBuffer>(range.Buffer);
             uint baseBuffer = GetBufferBase(set, stages != ShaderStages.Compute);
             if (stages == ShaderStages.Compute)
             {
-                _cce.setBuffer(mtlBuffer.DeviceBuffer, (UIntPtr)range.Offset, (UIntPtr)(slot + baseBuffer));
+                UIntPtr index = (UIntPtr)(slot + baseBuffer);
+
+                if (!_boundComputeBuffers.TryGetValue(index, out var boundBuffer) || !range.Equals(boundBuffer))
+                {
+                    _cce.setBuffer(mtlBuffer.DeviceBuffer, (UIntPtr)range.Offset, (UIntPtr)(slot + baseBuffer));
+                    _boundComputeBuffers[index] = range;
+                }
             }
             else
             {
@@ -914,46 +924,76 @@ namespace Veldrid.MTL
                     UIntPtr index = (UIntPtr)(_graphicsPipeline.ResourceBindingModel == ResourceBindingModel.Improved
                         ? slot + baseBuffer
                         : slot + _vertexBufferCount + baseBuffer);
-                    _rce.setVertexBuffer(mtlBuffer.DeviceBuffer, (UIntPtr)range.Offset, index);
+
+                    if (!_boundVertexBuffers.TryGetValue(index, out var boundBuffer) || !range.Equals(boundBuffer))
+                    {
+                        _rce.setVertexBuffer(mtlBuffer.DeviceBuffer, (UIntPtr)range.Offset, index);
+                        _boundVertexBuffers[index] = range;
+                    }
                 }
+
                 if ((stages & ShaderStages.Fragment) == ShaderStages.Fragment)
                 {
-                    _rce.setFragmentBuffer(mtlBuffer.DeviceBuffer, (UIntPtr)range.Offset, (UIntPtr)(slot + baseBuffer));
+                    UIntPtr index = (UIntPtr)(slot + baseBuffer);
+
+                    if (!_boundFragmentBuffers.TryGetValue(index, out var boundBuffer) || !range.Equals(boundBuffer))
+                    {
+                        _rce.setFragmentBuffer(mtlBuffer.DeviceBuffer, (UIntPtr)range.Offset, (UIntPtr)(slot + baseBuffer));
+                        _boundFragmentBuffers[index] = range;
+                    }
                 }
             }
         }
+
+        private readonly Dictionary<UIntPtr, MetalBindings.MTLTexture> _boundVertexTextures = new Dictionary<UIntPtr, MetalBindings.MTLTexture>();
+        private readonly Dictionary<UIntPtr, MetalBindings.MTLTexture> _boundFragmentTextures = new Dictionary<UIntPtr, MetalBindings.MTLTexture>();
+        private readonly Dictionary<UIntPtr, MetalBindings.MTLTexture> _boundComputeTextures = new Dictionary<UIntPtr, MetalBindings.MTLTexture>();
 
         private void BindTexture(MTLTextureView mtlTexView, uint set, uint slot, ShaderStages stages)
         {
             uint baseTexture = GetTextureBase(set, stages != ShaderStages.Compute);
-            if (stages == ShaderStages.Compute)
+            UIntPtr index = (UIntPtr)(slot + baseTexture);
+
+            if (stages == ShaderStages.Compute && (!_boundComputeTextures.TryGetValue(index, out var computeTexture) || computeTexture.NativePtr != mtlTexView.TargetDeviceTexture.NativePtr))
             {
-                _cce.setTexture(mtlTexView.TargetDeviceTexture, (UIntPtr)(slot + baseTexture));
+                _cce.setTexture(mtlTexView.TargetDeviceTexture, index);
+                _boundComputeTextures[index] = mtlTexView.TargetDeviceTexture;
             }
-            if ((stages & ShaderStages.Vertex) == ShaderStages.Vertex)
+            if ((stages & ShaderStages.Vertex) == ShaderStages.Vertex && (!_boundVertexTextures.TryGetValue(index, out var vertexTexture) || vertexTexture.NativePtr != mtlTexView.TargetDeviceTexture.NativePtr))
             {
-                _rce.setVertexTexture(mtlTexView.TargetDeviceTexture, (UIntPtr)(slot + baseTexture));
+                _rce.setVertexTexture(mtlTexView.TargetDeviceTexture, index);
+                _boundVertexTextures[index] = mtlTexView.TargetDeviceTexture;
             }
-            if ((stages & ShaderStages.Fragment) == ShaderStages.Fragment)
+            if ((stages & ShaderStages.Fragment) == ShaderStages.Fragment && (!_boundFragmentTextures.TryGetValue(index, out var fragmentTexture) || fragmentTexture.NativePtr != mtlTexView.TargetDeviceTexture.NativePtr))
             {
-                _rce.setFragmentTexture(mtlTexView.TargetDeviceTexture, (UIntPtr)(slot + baseTexture));
+                _rce.setFragmentTexture(mtlTexView.TargetDeviceTexture, index);
+                _boundFragmentTextures[index] = mtlTexView.TargetDeviceTexture;
             }
         }
+
+        private readonly Dictionary<UIntPtr, MTLSamplerState> _boundVertexSamplers = new Dictionary<UIntPtr, MTLSamplerState>();
+        private readonly Dictionary<UIntPtr, MTLSamplerState> _boundFragmentSamplers = new Dictionary<UIntPtr, MTLSamplerState>();
+        private readonly Dictionary<UIntPtr, MTLSamplerState> _boundComputeSamplers = new Dictionary<UIntPtr, MTLSamplerState>();
 
         private void BindSampler(MTLSampler mtlSampler, uint set, uint slot, ShaderStages stages)
         {
             uint baseSampler = GetSamplerBase(set, stages != ShaderStages.Compute);
-            if (stages == ShaderStages.Compute)
+            UIntPtr index = (UIntPtr)(slot + baseSampler);
+
+            if (stages == ShaderStages.Compute && (!_boundComputeSamplers.TryGetValue(index, out var computeSampler) || computeSampler.NativePtr != mtlSampler.DeviceSampler.NativePtr))
             {
-                _cce.setSamplerState(mtlSampler.DeviceSampler, (UIntPtr)(slot + baseSampler));
+                _cce.setSamplerState(mtlSampler.DeviceSampler, index);
+                _boundComputeSamplers[index] = mtlSampler.DeviceSampler;
             }
-            if ((stages & ShaderStages.Vertex) == ShaderStages.Vertex)
+            if ((stages & ShaderStages.Vertex) == ShaderStages.Vertex && (!_boundVertexSamplers.TryGetValue(index, out var vertexSampler) || vertexSampler.NativePtr != mtlSampler.DeviceSampler.NativePtr))
             {
-                _rce.setVertexSamplerState(mtlSampler.DeviceSampler, (UIntPtr)(slot + baseSampler));
+                _rce.setVertexSamplerState(mtlSampler.DeviceSampler, index);
+                _boundVertexSamplers[index] = mtlSampler.DeviceSampler;
             }
-            if ((stages & ShaderStages.Fragment) == ShaderStages.Fragment)
+            if ((stages & ShaderStages.Fragment) == ShaderStages.Fragment && (!_boundFragmentSamplers.TryGetValue(index, out var fragmentSampler) || fragmentSampler.NativePtr != mtlSampler.DeviceSampler.NativePtr))
             {
-                _rce.setFragmentSamplerState(mtlSampler.DeviceSampler, (UIntPtr)(slot + baseSampler));
+                _rce.setFragmentSamplerState(mtlSampler.DeviceSampler, index);
+                _boundFragmentSamplers[index] = mtlSampler.DeviceSampler;
             }
         }
 
@@ -1071,6 +1111,12 @@ namespace Veldrid.MTL
             _rce = default(MTLRenderCommandEncoder);
 
             _lastGraphicsPipeline = null;
+            _boundVertexBuffers.Clear();
+            _boundVertexTextures.Clear();
+            _boundVertexSamplers.Clear();
+            _boundFragmentBuffers.Clear();
+            _boundFragmentTextures.Clear();
+            _boundFragmentSamplers.Clear();
             Util.ClearArray(_graphicsResourceSetsActive);
 
             _viewportsChanged = true;
@@ -1133,7 +1179,12 @@ namespace Veldrid.MTL
                 _cce.endEncoding();
                 ObjectiveCRuntime.release(_cce.NativePtr);
                 _cce = default(MTLComputeCommandEncoder);
+
+                _boundComputeBuffers.Clear();
+                _boundComputeTextures.Clear();
+                _boundComputeSamplers.Clear();
                 _lastComputePipeline = null;
+
                 Util.ClearArray(_computeResourceSetsActive);
             }
 

--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -24,8 +24,8 @@ namespace Veldrid.MTL
         private MTLIndexType _indexType;
         private MTLPipeline _lastGraphicsPipeline;
         private new MTLPipeline _graphicsPipeline;
+        private MTLPipeline _lastComputePipeline;
         private new MTLPipeline _computePipeline;
-        private bool _computePipelineChanged;
         private MTLViewport[] _viewports = Array.Empty<MTLViewport>();
         private bool _viewportsChanged;
         private MTLScissorRect[] _scissorRects = Array.Empty<MTLScissorRect>();
@@ -268,10 +268,11 @@ namespace Veldrid.MTL
         private void PreComputeCommand()
         {
             EnsureComputeEncoder();
-            if (_computePipelineChanged)
-            {
+
+            if (_computePipeline.ComputePipelineState.NativePtr != _lastComputePipeline?.ComputePipelineState.NativePtr)
                 _cce.setComputePipelineState(_computePipeline.ComputePipelineState);
-            }
+
+            _lastComputePipeline = _computePipeline;
 
             for (uint i = 0; i < _computeResourceSetCount; i++)
             {
@@ -304,7 +305,6 @@ namespace Veldrid.MTL
                 Util.EnsureArrayMinimumSize(ref _computeResourceSets, _computeResourceSetCount);
                 Util.EnsureArrayMinimumSize(ref _computeResourceSetsActive, _computeResourceSetCount);
                 Util.ClearArray(_computeResourceSetsActive);
-                _computePipelineChanged = true;
             }
             else
             {
@@ -1133,7 +1133,7 @@ namespace Veldrid.MTL
                 _cce.endEncoding();
                 ObjectiveCRuntime.release(_cce.NativePtr);
                 _cce = default(MTLComputeCommandEncoder);
-                _computePipelineChanged = true;
+                _lastComputePipeline = null;
                 Util.ClearArray(_computeResourceSetsActive);
             }
 

--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -298,7 +298,7 @@ namespace Veldrid.MTL
 
         private protected override void SetPipelineCore(Pipeline pipeline)
         {
-            if (pipeline.IsComputePipeline)
+            if (pipeline.IsComputePipeline && _computePipeline != pipeline)
             {
                 _computePipeline = Util.AssertSubtype<Pipeline, MTLPipeline>(pipeline);
                 _computeResourceSetCount = (uint)_computePipeline.ResourceLayouts.Length;
@@ -306,7 +306,7 @@ namespace Veldrid.MTL
                 Util.EnsureArrayMinimumSize(ref _computeResourceSetsActive, _computeResourceSetCount);
                 Util.ClearArray(_computeResourceSetsActive);
             }
-            else
+            else if (!pipeline.IsComputePipeline && _graphicsPipeline != pipeline)
             {
                 _graphicsPipeline = Util.AssertSubtype<Pipeline, MTLPipeline>(pipeline);
                 _graphicsResourceSetCount = (uint)_graphicsPipeline.ResourceLayouts.Length;


### PR DESCRIPTION
Rebased changes from https://github.com/mellinoe/veldrid/pull/499.