### PR TITLE
Choose higher D3D11 shader profiles on feature level 11_0+

### DIFF
--- a/src/Veldrid/BackendInfoD3D11.cs
+++ b/src/Veldrid/BackendInfoD3D11.cs
@@ -1,6 +1,7 @@
 ﻿#if !EXCLUDE_D3D11_BACKEND
 using System;
 using Veldrid.D3D11;
+using Vortice.Direct3D;
 
 namespace Veldrid
 {
@@ -27,6 +28,11 @@ namespace Veldrid
         /// Gets a pointer to the IAdapter used to create the GraphicsDevice.
         /// </summary>
         public IntPtr Adapter => _gd.Adapter.NativePointer;
+
+        /// <summary>
+        /// Returns the feature level of the D3D11 device.
+        /// </summary>
+        public FeatureLevel FeatureLevel => _gd.Device.FeatureLevel;
 
         /// <summary>
         /// Gets the PCI ID of the hardware device.

--- a/src/Veldrid/D3D11/D3D11Shader.cs
+++ b/src/Veldrid/D3D11/D3D11Shader.cs
@@ -8,6 +8,7 @@ namespace Veldrid.D3D11
 {
     internal class D3D11Shader : Shader
     {
+        private readonly ID3D11Device _device;
         private string _name;
 
         public ID3D11DeviceChild DeviceShader { get; }
@@ -16,6 +17,8 @@ namespace Veldrid.D3D11
         public D3D11Shader(ID3D11Device device, ShaderDescription description)
             : base(description.Stage, description.EntryPoint)
         {
+            _device = device;
+
             if (description.ShaderBytes.Length > 4
                 && description.ShaderBytes[0] == 0x44
                 && description.ShaderBytes[1] == 0x58
@@ -60,22 +63,22 @@ namespace Veldrid.D3D11
             switch (description.Stage)
             {
                 case ShaderStages.Vertex:
-                    profile = "vs_4_0";
+                    profile = _device.FeatureLevel >= FeatureLevel.Level_11_0 ? "vs_5_0" : "vs_4_0";
                     break;
                 case ShaderStages.Geometry:
-                    profile = "gs_4_0";
+                    profile = _device.FeatureLevel >= FeatureLevel.Level_11_0 ? "gs_5_0" : "gs_4_0";
                     break;
                 case ShaderStages.TessellationControl:
-                    profile = "hs_4_0";
+                    profile = _device.FeatureLevel >= FeatureLevel.Level_11_0 ? "hs_5_0" : "hs_4_0";
                     break;
                 case ShaderStages.TessellationEvaluation:
-                    profile = "ds_4_0";
+                    profile = _device.FeatureLevel >= FeatureLevel.Level_11_0 ? "ds_5_0" : "ds_4_0";
                     break;
                 case ShaderStages.Fragment:
-                    profile = "ps_4_0";
+                    profile = _device.FeatureLevel >= FeatureLevel.Level_11_0 ? "ps_5_0" : "ps_4_0";
                     break;
                 case ShaderStages.Compute:
-                    profile = "cs_4_0";
+                    profile = _device.FeatureLevel >= FeatureLevel.Level_11_0 ? "cs_5_0" : "cs_4_0";
                     break;
                 default:
                     throw Illegal.Value<ShaderStages>();


### PR DESCRIPTION
This allows benefiting from `cs_5_0` features when running on feature level 11 or higher (mainly binding textures for read-write in compute shaders, which will be used for mipmap generation).