### PR TITLE
Fix `CADisplayLink` not working

### DIFF
--- a/src/Veldrid.MetalBindings/metal-mono-workaround/metal-mono-workaround/metal_mono_workaround.m
+++ b/src/Veldrid.MetalBindings/metal-mono-workaround/metal-mono-workaround/metal_mono_workaround.m
@@ -8,11 +8,14 @@
 - (nonnull instancetype)initWithCallback:(nonnull CADisplayLinkCallback)callback {
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector: @selector(onDisplayLinkCallback:)];
     _callback = callback;
+
+    [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+
     return self;
 }
 
 - (void)onDisplayLinkCallback:(id)displayLink {
-    _callback((void*)&self);
+    _callback((__bridge void*)self);
 }
 
 @end

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -704,9 +704,10 @@ namespace Veldrid.D3D11
         {
         }
 
-        private protected override void WaitForNextFrameReadyCore()
+        private protected override bool WaitForNextFrameReadyCore()
         {
             _mainSwapchain.WaitForNextFrameReady();
+            return true;
         }
 
         public override bool GetD3D11Info(out BackendInfoD3D11 info)

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -278,9 +278,9 @@ namespace Veldrid
         /// In contrast to <see cref="Swapchain.SyncToVerticalBlank"/>, this allows the next frame to be rendered as soon
         /// as the next GPU buffer becomes available without incurring the extra frame of latency of <see cref="Swapchain.SyncToVerticalBlank"/>.
         /// </summary>
-        public void WaitForNextFrameReady() => WaitForNextFrameReadyCore();
+        public bool WaitForNextFrameReady() => WaitForNextFrameReadyCore();
 
-        private protected abstract void WaitForNextFrameReadyCore();
+        private protected abstract bool WaitForNextFrameReadyCore();
 
         /// <summary>
         /// Gets the maximum sample count supported by the given <see cref="PixelFormat"/>.

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -44,7 +44,7 @@ namespace Veldrid.MTL
         private readonly IntPtr _completionBlockLiteral;
 
         private readonly IMTLDisplayLink _displayLink;
-        private int _nextFrameReady;
+        private int _nextFrameReady = 1;
 
         public MTLDevice Device => _device;
         public MTLCommandQueue CommandQueue => _commandQueue;

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -822,8 +822,9 @@ namespace Veldrid.OpenGL
             _executionThread.WaitForIdle();
         }
 
-        private protected override void WaitForNextFrameReadyCore()
+        private protected override bool WaitForNextFrameReadyCore()
         {
+            return true;
         }
 
         public override TextureSampleCount GetSampleCountLimit(PixelFormat format, bool depthFormat)

--- a/src/Veldrid/Vk/VkGraphicsDevice.cs
+++ b/src/Veldrid/Vk/VkGraphicsDevice.cs
@@ -1087,8 +1087,9 @@ namespace Veldrid.Vk
             CheckSubmittedFences();
         }
 
-        private protected override void WaitForNextFrameReadyCore()
+        private protected override bool WaitForNextFrameReadyCore()
         {
+            return true;
         }
 
         public override TextureSampleCount GetSampleCountLimit(PixelFormat format, bool depthFormat)


### PR DESCRIPTION
This is not really the proper way of doing this, but I don't have a better solution right now.

`CADisplayLink` is attached to a particular thread. It can only run within the context of that thread (likely at the start of that thread's execution loop). It does not provide messages asynchronously.

In the default execution mode of o!f on iOS, we draw on the main thread in a single-threaded fashion. This means we cannot block `DrawFrame()` whilst waiting for `CADisplayLink` to signal us, because it never will until the thread's next loop.

Ideally, the structure of o!f would be inverted so that `CADisplayLink` wraps the main thread, but this is exceedingly complex to make work. Maybe someone with more insight into the process (`ThreadRunner`, the SDL window loop, etc) could attempt this.

Instead, I've made `WaitForNextFrameReady()` return a `bool` parameter of `false` if the current frame should be skipped.

Apart from the obvious timing drawback - that we have to synchronise our thread's loop with the conditional, the other drawback is that the FPS counter and graph are a bit broken.

For what it's worth, the exact signature of `WaitForNextFrameReady()` is still in a bit of a state of flux as it's not yet upstreamed. The upstream suggestion (https://github.com/veldrid/veldrid/pull/485) is to use a fence, however I don't believe a fence will be adequate for a proper implementation here either. Better might be to expose an event for o!f/consumers to bind the draw procedure to.