### PR TITLE
add `DisplayLinkUpdateActiveMonitor` to MTLGraphicsDevice for updating `CVDisplayLink` current display

### DIFF
--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -969,22 +969,22 @@ namespace Veldrid
         }
 
         /// <summary>
-        /// Updates CVDisplayLink active display using the display's origin and size.
+        /// Updates the active display using the display's origin and size.
         /// </summary>
         /// <param name="x"></param> x coordinate of the display's origin
         /// <param name="y"></param> y coordinate of the display's origin
         /// <param name="w"></param> display's width
         /// <param name="h"></param> display's height
-        public virtual void UpdateActiveMonitor(int x, int y, int w, int h)
+        public virtual void UpdateActiveDisplay(int x, int y, int w, int h)
         {
             return;
         }
 
         /// <summary>
-        /// Calls CVDisplayLinkGetActualOutputVideoRefreshPeriod
+        /// If running on MTL, retrieves the refresh period of the currently active display.
         /// </summary>
         /// <returns>The actual refresh period of the currently selected CVDisplayLink display in seconds</returns>
-        public virtual double DisplayLinkGetActualOutputVideoRefreshPeriod()
+        public virtual double GetActualRefreshPeriod()
         {
             return -1.0f;
         }

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -977,13 +977,12 @@ namespace Veldrid
         /// <param name="h"></param> display's height
         public virtual void UpdateActiveDisplay(int x, int y, int w, int h)
         {
-            return;
         }
 
         /// <summary>
-        /// If running on MTL, retrieves the refresh period of the currently active display.
+        /// Retrieves the refresh period of the currently active display, or -1 if not supported.
         /// </summary>
-        /// <returns>The actual refresh period of the currently selected CVDisplayLink display in seconds</returns>
+        /// <returns>The actual refresh period (seconds per frame) of the currently selected display in seconds.</returns>
         public virtual double GetActualRefreshPeriod()
         {
             return -1.0f;

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -39,7 +39,7 @@ namespace Veldrid
 
         /// <summary>
         /// Gets a value identifying whether texture coordinates begin in the top left corner of a Texture.
-        /// If true, (0, 0) refers to the top-left texel of a Texture. If false, (0, 0) refers to the bottom-left 
+        /// If true, (0, 0) refers to the top-left texel of a Texture. If false, (0, 0) refers to the bottom-left
         /// texel of a Texture. This property is useful for determining how the output of a Framebuffer should be sampled.
         /// </summary>
         public abstract bool IsUvOriginTopLeft { get; }
@@ -975,7 +975,7 @@ namespace Veldrid
         /// <param name="y"></param> y coordinate of the display's origin
         /// <param name="w"></param> display's width
         /// <param name="h"></param> display's height
-        public virtual void DisplayLinkUpdateActiveMonitor(int x, int y, int w, int h)
+        public virtual void UpdateActiveMonitor(int x, int y, int w, int h)
         {
             return;
         }

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -967,6 +967,27 @@ namespace Veldrid
 
             return info;
         }
+
+        /// <summary>
+        /// Updates CVDisplayLink active display using the display's origin and size.
+        /// </summary>
+        /// <param name="x"></param> x coordinate of the display's origin
+        /// <param name="y"></param> y coordinate of the display's origin
+        /// <param name="w"></param> display's width
+        /// <param name="h"></param> display's height
+        public virtual void DisplayLinkUpdateActiveMonitor(int x, int y, int w, int h)
+        {
+            return;
+        }
+
+        /// <summary>
+        /// Calls CVDisplayLinkGetActualOutputVideoRefreshPeriod
+        /// </summary>
+        /// <returns>The actual refresh period of the currently selected CVDisplayLink display in seconds</returns>
+        public virtual double DisplayLinkGetActualOutputVideoRefreshPeriod()
+        {
+            return -1.0f;
+        }
 #endif
 
         /// <summary>

--- a/src/Veldrid/MTL/IMTLDisplayLink.cs
+++ b/src/Veldrid/MTL/IMTLDisplayLink.cs
@@ -9,6 +9,6 @@ namespace Veldrid.MTL
     {
         event Action Callback;
         public double GetActualOutputVideoRefreshPeriod();
-        public void UpdateActiveMonitor(int x, int y, int w, int h);
+        public void UpdateActiveDisplay(int x, int y, int w, int h);
     }
 }

--- a/src/Veldrid/MTL/IMTLDisplayLink.cs
+++ b/src/Veldrid/MTL/IMTLDisplayLink.cs
@@ -8,5 +8,7 @@ namespace Veldrid.MTL
     internal interface IMTLDisplayLink : IDisposable
     {
         event Action Callback;
+        public double GetActualOutputVideoRefreshPeriod();
+        public void UpdateActiveMonitor(int x, int y, int w, int h);
     }
 }

--- a/src/Veldrid/MTL/MTLCVDisplayLink.cs
+++ b/src/Veldrid/MTL/MTLCVDisplayLink.cs
@@ -21,6 +21,16 @@ namespace Veldrid.MTL
             _displayLink.Start();
         }
 
+        public void UpdateActiveMonitor(int x, int y, int w, int h)
+        {
+            _displayLink.UpdateActiveMonitor(x, y, w, h);
+        }
+
+        public double GetActualOutputVideoRefreshPeriod()
+        {
+            return _displayLink.GetActualOutputVideoRefreshPeriod();
+        }
+
         private int OnCallback(CVDisplayLink displaylink, CVTimeStamp* innow, CVTimeStamp* inoutputtime, long flagsin, long flagsout, IntPtr userdata)
         {
             Callback?.Invoke();

--- a/src/Veldrid/MTL/MTLCVDisplayLink.cs
+++ b/src/Veldrid/MTL/MTLCVDisplayLink.cs
@@ -21,7 +21,7 @@ namespace Veldrid.MTL
             _displayLink.Start();
         }
 
-        public void UpdateActiveMonitor(int x, int y, int w, int h)
+        public void UpdateActiveDisplay(int x, int y, int w, int h)
         {
             _displayLink.UpdateActiveMonitor(x, y, w, h);
         }

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -57,6 +57,23 @@ namespace Veldrid.MTL
         {
         }
 
+        public override void DisplayLinkUpdateActiveMonitor(int x, int y, int w, int h)
+        {
+            if (_displayLink != null)
+            {
+                _displayLink.UpdateActiveMonitor(x, y, w, h);
+            }
+        }
+
+        public override double DisplayLinkGetActualOutputVideoRefreshPeriod()
+        {
+            if (_displayLink != null)
+            {
+                return _displayLink.GetActualOutputVideoRefreshPeriod();
+            }
+            return -1.0f;
+        }
+
         public MTLGraphicsDevice(
             GraphicsDeviceOptions options,
             SwapchainDescription? swapchainDesc,

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -57,7 +57,7 @@ namespace Veldrid.MTL
         {
         }
 
-        public override void UpdateActiveMonitor(int x, int y, int w, int h)
+        public override void UpdateActiveDisplay(int x, int y, int w, int h)
         {
             if (_displayLink != null)
             {
@@ -65,7 +65,7 @@ namespace Veldrid.MTL
             }
         }
 
-        public override double DisplayLinkGetActualOutputVideoRefreshPeriod()
+        public override double GetActualRefreshPeriod()
         {
             if (_displayLink != null)
             {

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -62,7 +62,8 @@ namespace Veldrid.MTL
         {
             if (_displayLink != null)
             {
-                _displayLink.UpdateActiveMonitor(x, y, w, h);
+                _frameEndedEvent.Set();
+                _displayLink.UpdateActiveDisplay(x, y, w, h);
             }
         }
 

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -72,6 +72,7 @@ namespace Veldrid.MTL
             {
                 return _displayLink.GetActualOutputVideoRefreshPeriod();
             }
+
             return -1.0f;
         }
 

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -45,7 +45,7 @@ namespace Veldrid.MTL
 
         private readonly IMTLDisplayLink _displayLink;
         private readonly AutoResetEvent _nextFrameReadyEvent;
-        private readonly AutoResetEvent _frameEndedEvent = new AutoResetEvent(true);
+        private readonly EventWaitHandle _frameEndedEvent = new EventWaitHandle(true, EventResetMode.ManualReset);
 
         public MTLDevice Device => _device;
         public MTLCommandQueue CommandQueue => _commandQueue;
@@ -62,7 +62,6 @@ namespace Veldrid.MTL
         {
             if (_displayLink != null)
             {
-                _frameEndedEvent.Set();
                 _displayLink.UpdateActiveDisplay(x, y, w, h);
             }
         }
@@ -248,6 +247,7 @@ namespace Veldrid.MTL
 
         private protected override void WaitForNextFrameReadyCore()
         {
+            _frameEndedEvent.Reset();
             _nextFrameReadyEvent?.WaitOne(TimeSpan.FromSeconds(1)); // Should never time out.
         }
 

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -57,7 +57,7 @@ namespace Veldrid.MTL
         {
         }
 
-        public override void DisplayLinkUpdateActiveMonitor(int x, int y, int w, int h)
+        public override void UpdateActiveMonitor(int x, int y, int w, int h)
         {
             if (_displayLink != null)
             {


### PR DESCRIPTION
This allows a user of the renderer to update the CVDisplayLink's current display by passing the active display's origin coordinates and size. 

This is needed to correctly set CVDisplayLink's target refresh rate when:
- the window is moved across monitors
- CVDisplayLinkCreateWithActiveCGDisplays (at [Veldrid.MetalBindings/CVDisplayLink.cs#L21](https://github.com/ILW8/veldrid/blob/542b3f255923610b8fb4e114f3f832ee3cbe0cbd/src/Veldrid.MetalBindings/CVDisplayLink.cs#LL21C13-L21C76)) doesn't return a CVDisplayLink set to the correct refresh rate; I've noticed this is especially prevalent when the high refresh rate monitor is mirrored to another lower refresh rate monitor, or in the case where the main monitor is 60Hz but a game using Veldrid is being run on a different high refresh rate monitor.

I'm using origin and size because it's the only relatively straightforward way of finding the correct [CGDirectDisplayID](https://developer.apple.com/documentation/coregraphics/cgdirectdisplayid) for calling [CVDisplayLinkSetCurrentCGDisplay](https://developer.apple.com/documentation/corevideo/1456768-cvdisplaylinksetcurrentcgdisplay) with (that I could find). 

I feel that the way things are laid out (having such a deep call stack until actually calling CVDisplayLinkSetCurrentCGDisplay) is not great, but I'm not sure how else this should be laid out. I wouldn't mind if this code is completely thrown out in favour of something else, but at least this code should give an idea of what needs to be done.