### PR TITLE
Wait in `CVDisplayLink` callback until frame rendering has finished

### DIFF
--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -45,6 +45,7 @@ namespace Veldrid.MTL
 
         private readonly IMTLDisplayLink _displayLink;
         private readonly AutoResetEvent _nextFrameReadyEvent;
+        private readonly AutoResetEvent _frameEndedEvent = new AutoResetEvent(true);
 
         public MTLDevice Device => _device;
         public MTLCommandQueue CommandQueue => _commandQueue;
@@ -234,6 +235,7 @@ namespace Veldrid.MTL
         private void OnDisplayLinkCallback()
         {
             _nextFrameReadyEvent.Set();
+            _frameEndedEvent.WaitOne();
         }
 
         public override TextureSampleCount GetSampleCountLimit(PixelFormat format, bool depthFormat)
@@ -335,6 +337,8 @@ namespace Veldrid.MTL
 
                 mtlSC.InvalidateDrawable();
             }
+
+            _frameEndedEvent.Set();
         }
 
         private protected override void UpdateBufferCore(DeviceBuffer buffer, uint bufferOffsetInBytes, IntPtr source, uint sizeInBytes)


### PR DESCRIPTION
Turns out this will give more consistent results.

Tested by alt-tabbing multiple times on macOS to give expedited results, but in normal scenarios, the game ends up falling back to the mode where it is no longer waiting on `WaitUntilNextFrame` and instead gets stuck mid-render, adding an extra frame of latency. You can see this happening when the sleep time (dark blue) becomes actual draw overhead, and we get stuck in this call stack:

![JetBrains Rider 2023-06-13 at 07 13 45](https://github.com/ppy/veldrid/assets/191335/573ff502-f897-4064-a440-3cb057d4790a)

This change brings vsync latency down from 2 frames to 1 frame, making it very usable again.

Before:

![osu Framework Tests 2023-06-13 at 08 43 36](https://github.com/ppy/veldrid/assets/191335/8128452c-5568-4f29-b7d0-aadc3449c1d3)


After:

![osu Framework Tests 2023-06-13 at 08 41 36](https://github.com/ppy/veldrid/assets/191335/e8244f54-ec1b-4d08-bf8e-1dada3d39610)
