### PR TITLE
Always cache Metal selectors to avoid fetch overhead during API calls

### DIFF
--- a/src/Veldrid.MetalBindings/CALayer.cs
+++ b/src/Veldrid.MetalBindings/CALayer.cs
@@ -12,7 +12,9 @@ namespace Veldrid.MetalBindings
 
         public void addSublayer(IntPtr layer)
         {
-            objc_msgSend(NativePtr, "addSublayer:", layer);
+            objc_msgSend(NativePtr, sel_addSublayer, layer);
         }
+
+        private static readonly Selector sel_addSublayer = "addSublayer:";
     }
 }

--- a/src/Veldrid.MetalBindings/CAMetalLayer.cs
+++ b/src/Veldrid.MetalBindings/CAMetalLayer.cs
@@ -51,22 +51,22 @@ namespace Veldrid.MetalBindings
 
         public CGRect frame
         {
-            get => CGRect_objc_msgSend(NativePtr, "frame");
-            set => objc_msgSend(NativePtr, "setFrame:", value);
+            get => CGRect_objc_msgSend(NativePtr, sel_frame);
+            set => objc_msgSend(NativePtr, sel_setFrame, value);
         }
 
         public Bool8 opaque
         {
-            get => bool8_objc_msgSend(NativePtr, "isOpaque");
-            set => objc_msgSend(NativePtr, "setOpaque:", value);
+            get => bool8_objc_msgSend(NativePtr, sel_isOpaque);
+            set => objc_msgSend(NativePtr, sel_setOpaque, value);
         }
 
         public CAMetalDrawable nextDrawable() => objc_msgSend<CAMetalDrawable>(NativePtr, sel_nextDrawable);
 
         public Bool8 displaySyncEnabled
         {
-            get => bool8_objc_msgSend(NativePtr, "displaySyncEnabled");
-            set => objc_msgSend(NativePtr, "setDisplaySyncEnabled:", value);
+            get => bool8_objc_msgSend(NativePtr, sel_displaySyncEnabled);
+            set => objc_msgSend(NativePtr, sel_setDisplaySyncEnabled, value);
         }
 
         private static readonly ObjCClass s_class = new ObjCClass(nameof(CAMetalLayer));
@@ -78,6 +78,12 @@ namespace Veldrid.MetalBindings
         private static readonly Selector sel_setFramebufferOnly = "setFramebufferOnly:";
         private static readonly Selector sel_drawableSize = "drawableSize";
         private static readonly Selector sel_setDrawableSize = "setDrawableSize:";
+        private static readonly Selector sel_frame = "frame";
+        private static readonly Selector sel_setFrame = "setFrame:";
+        private static readonly Selector sel_isOpaque = "isOpaque";
+        private static readonly Selector sel_setOpaque = "setOpaque:";
+        private static readonly Selector sel_displaySyncEnabled = "displaySyncEnabled";
+        private static readonly Selector sel_setDisplaySyncEnabled = "setDisplaySyncEnabled:";
         private static readonly Selector sel_nextDrawable = "nextDrawable";
     }
 }

--- a/src/Veldrid.MetalBindings/NSDictionary.cs
+++ b/src/Veldrid.MetalBindings/NSDictionary.cs
@@ -6,6 +6,8 @@ namespace Veldrid.MetalBindings
     {
         public readonly IntPtr NativePtr;
 
-        public UIntPtr count => ObjectiveCRuntime.UIntPtr_objc_msgSend(NativePtr, "count");
+        public UIntPtr count => ObjectiveCRuntime.UIntPtr_objc_msgSend(NativePtr, sel_count);
+
+        private static readonly Selector sel_count = "count";
     }
 }

--- a/src/Veldrid.MetalBindings/NSError.cs
+++ b/src/Veldrid.MetalBindings/NSError.cs
@@ -6,7 +6,10 @@ namespace Veldrid.MetalBindings
     public struct NSError
     {
         public readonly IntPtr NativePtr;
-        public string domain => string_objc_msgSend(NativePtr, "domain");
-        public string localizedDescription => string_objc_msgSend(NativePtr, "localizedDescription");
+        public string domain => string_objc_msgSend(NativePtr, sel_domain);
+        public string localizedDescription => string_objc_msgSend(NativePtr, sel_localizedDescription);
+
+        private static readonly Selector sel_domain = "domain";
+        private static readonly Selector sel_localizedDescription = "localizedDescription";
     }
 }

--- a/src/Veldrid.MetalBindings/NSView.cs
+++ b/src/Veldrid.MetalBindings/NSView.cs
@@ -13,19 +13,25 @@ namespace Veldrid.MetalBindings
 
         public Bool8 wantsLayer
         {
-            get => bool8_objc_msgSend(NativePtr, "wantsLayer");
-            set => objc_msgSend(NativePtr, "setWantsLayer:", value);
+            get => bool8_objc_msgSend(NativePtr, sel_wantsLayer);
+            set => objc_msgSend(NativePtr, sel_setWantsLayer, value);
         }
 
         public IntPtr layer
         {
-            get => IntPtr_objc_msgSend(NativePtr, "layer");
-            set => objc_msgSend(NativePtr, "setLayer:", value);
+            get => IntPtr_objc_msgSend(NativePtr, sel_layer);
+            set => objc_msgSend(NativePtr, sel_setLayer, value);
         }
 
         public CGRect frame =>
             RuntimeInformation.ProcessArchitecture == Architecture.Arm64
-                ? CGRect_objc_msgSend(NativePtr, "frame")
-                : objc_msgSend_stret<CGRect>(NativePtr, "frame");
+                ? CGRect_objc_msgSend(NativePtr, sel_frame)
+                : objc_msgSend_stret<CGRect>(NativePtr, sel_frame);
+
+        private static readonly Selector sel_wantsLayer = "wantsLayer";
+        private static readonly Selector sel_setWantsLayer = "setWantsLayer:";
+        private static readonly Selector sel_layer = "layer";
+        private static readonly Selector sel_setLayer = "setLayer:";
+        private static readonly Selector sel_frame = "frame";
     }
 }

--- a/src/Veldrid.MetalBindings/NSWindow.cs
+++ b/src/Veldrid.MetalBindings/NSWindow.cs
@@ -11,6 +11,8 @@ namespace Veldrid.MetalBindings
             NativePtr = ptr;
         }
 
-        public NSView contentView => objc_msgSend<NSView>(NativePtr, "contentView");
+        public NSView contentView => objc_msgSend<NSView>(NativePtr, sel_contentView);
+
+        private static readonly Selector sel_contentView = "contentView";
     }
 }

--- a/src/Veldrid.MetalBindings/ObjectiveCRuntime.cs
+++ b/src/Veldrid.MetalBindings/ObjectiveCRuntime.cs
@@ -275,8 +275,13 @@ namespace Veldrid.MetalBindings
 
         [DllImport(ObjCLibrary)]
         public static extern void free(IntPtr receiver);
-        public static void retain(IntPtr receiver) => objc_msgSend(receiver, "retain");
-        public static void release(IntPtr receiver) => objc_msgSend(receiver, "release");
-        public static ulong GetRetainCount(IntPtr receiver) => (ulong)UIntPtr_objc_msgSend(receiver, "retainCount");
+
+        public static void retain(IntPtr receiver) => objc_msgSend(receiver, sel_retain);
+        public static void release(IntPtr receiver) => objc_msgSend(receiver, sel_release);
+        public static ulong GetRetainCount(IntPtr receiver) => (ulong)UIntPtr_objc_msgSend(receiver, sel_retainCount);
+
+        private static readonly Selector sel_retain = "retain";
+        private static readonly Selector sel_release = "release";
+        private static readonly Selector sel_retainCount = "retainCount";
     }
 }

--- a/src/Veldrid.MetalBindings/UIScreen.cs
+++ b/src/Veldrid.MetalBindings/UIScreen.cs
@@ -11,9 +11,12 @@ namespace Veldrid.MetalBindings
             NativePtr = ptr;
         }
 
-        public CGFloat nativeScale => CGFloat_objc_msgSend(NativePtr, "nativeScale");
+        public CGFloat nativeScale => CGFloat_objc_msgSend(NativePtr, sel_nativeScale);
 
         public static UIScreen mainScreen
-            => objc_msgSend<UIScreen>(new ObjCClass(nameof(UIScreen)), "mainScreen");
+            => objc_msgSend<UIScreen>(new ObjCClass(nameof(UIScreen)), sel_mainScreen);
+
+        private static readonly Selector sel_nativeScale = "nativeScale";
+        private static readonly Selector sel_mainScreen = "mainScreen";
     }
 }

--- a/src/Veldrid.MetalBindings/UIView.cs
+++ b/src/Veldrid.MetalBindings/UIView.cs
@@ -9,11 +9,14 @@ namespace Veldrid.MetalBindings
         public readonly IntPtr NativePtr;
         public UIView(IntPtr ptr) => NativePtr = ptr;
 
-        public CALayer layer => objc_msgSend<CALayer>(NativePtr, "layer");
+        public CALayer layer => objc_msgSend<CALayer>(NativePtr, sel_layer);
 
         public CGRect frame =>
             RuntimeInformation.ProcessArchitecture == Architecture.Arm64
-                ? CGRect_objc_msgSend(NativePtr, "frame")
-                : objc_msgSend_stret<CGRect>(NativePtr, "frame");
+                ? CGRect_objc_msgSend(NativePtr, sel_frame)
+                : objc_msgSend_stret<CGRect>(NativePtr, sel_frame);
+
+        private static readonly Selector sel_layer = "layer";
+        private static readonly Selector sel_frame = "frame";
     }
 }

--- a/src/Veldrid/MTL/MTLSwapchain.cs
+++ b/src/Veldrid/MTL/MTLSwapchain.cs
@@ -168,7 +168,7 @@ namespace Veldrid.MTL
         {
             if (_drawable.NativePtr != IntPtr.Zero)
             {
-                ObjectiveCRuntime.objc_msgSend(_drawable.NativePtr, "release");
+                ObjectiveCRuntime.release(_drawable.NativePtr);
             }
             _framebuffer.Dispose();
             ObjectiveCRuntime.release(_metalLayer.NativePtr);

--- a/src/Veldrid/OpenGL/EAGL/CAEAGLLayer.cs
+++ b/src/Veldrid/OpenGL/EAGL/CAEAGLLayer.cs
@@ -17,18 +17,24 @@ namespace Veldrid.OpenGL.EAGL
 
         public CGRect frame
         {
-            get => CGRect_objc_msgSend(NativePtr, "frame");
-            set => objc_msgSend(NativePtr, "setFrame:", value);
+            get => CGRect_objc_msgSend(NativePtr, sel_frame);
+            set => objc_msgSend(NativePtr, sel_setFrame, value);
         }
 
         public Bool8 opaque
         {
-            get => bool8_objc_msgSend(NativePtr, "isOpaque");
-            set => objc_msgSend(NativePtr, "setOpaque:", value);
+            get => bool8_objc_msgSend(NativePtr, sel_isOpaque);
+            set => objc_msgSend(NativePtr, sel_setOpaque, value);
         }
 
-        public void removeFromSuperlayer() => objc_msgSend(NativePtr, "removeFromSuperlayer");
+        public void removeFromSuperlayer() => objc_msgSend(NativePtr, sel_removeFromSuperlayer);
 
         public void Release() => release(NativePtr);
+
+        private static readonly Selector sel_frame = "frame";
+        private static readonly Selector sel_setFrame = "setFrame:";
+        private static readonly Selector sel_isOpaque = "isOpaque";
+        private static readonly Selector sel_setOpaque = "setOpaque:";
+        private static readonly Selector sel_removeFromSuperlayer = "removeFromSuperlayer";
     }
 }


### PR DESCRIPTION
`Selector` constructor contains native call overhead, so it's best to always cache selectors and re-use them rather than recreating one per call.