### PR TITLE
Fix Metal assertion failure when creating buffers with private memory access

### DIFF
--- a/src/Veldrid/MTL/MTLBuffer.cs
+++ b/src/Veldrid/MTL/MTLBuffer.cs
@@ -47,7 +47,8 @@ namespace Veldrid.MTL
 
             unsafe
             {
-                Pointer = DeviceBuffer.contents();
+                if (sharedMemory)
+                    Pointer = DeviceBuffer.contents();
             }
         }
 

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -365,6 +365,8 @@ namespace Veldrid.MTL
             var mtlBuffer = Util.AssertSubtype<DeviceBuffer, MTLBuffer>(buffer);
             void* destPtr = mtlBuffer.Pointer;
             byte* destOffsetPtr = (byte*)destPtr + bufferOffsetInBytes;
+
+            Debug.Assert(destPtr != null, "Attempting to write to a MTLBuffer that is inaccessible from a CPU.");
             Unsafe.CopyBlock(destOffsetPtr, source.ToPointer(), sizeInBytes);
         }
 

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -366,7 +366,9 @@ namespace Veldrid.MTL
             void* destPtr = mtlBuffer.Pointer;
             byte* destOffsetPtr = (byte*)destPtr + bufferOffsetInBytes;
 
-            Debug.Assert(destPtr != null, "Attempting to write to a MTLBuffer that is inaccessible from a CPU.");
+            if (destPtr == null)
+                throw new VeldridException("Attempting to write to a MTLBuffer that is inaccessible from a CPU.");
+
             Unsafe.CopyBlock(destOffsetPtr, source.ToPointer(), sizeInBytes);
         }
 


### PR DESCRIPTION
- First step towards resolving https://github.com/ppy/osu/issues/23970

Calling `contents` on a buffer with private memory access returns` null` results in the following assertion failure:
```
-[MTLToolsResource validateCPUWriteable]:135: failed assertion `resourceOptions (0x20) specify MTLResourceStorageModePrivate, which is not CPU accessible.'
```