### PR TITLE
Remove manual command buffer release logic

### DIFF
--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -70,16 +70,7 @@ namespace Veldrid.MTL
 
         public override void Begin()
         {
-            if (_cb.NativePtr != IntPtr.Zero)
-            {
-                ObjectiveCRuntime.release(_cb.NativePtr);
-            }
-
-            using (NSAutoreleasePool.Begin())
-            {
-                _cb = _gd.CommandQueue.commandBuffer();
-                ObjectiveCRuntime.retain(_cb.NativePtr);
-            }
+            _cb = _gd.CommandQueue.commandBuffer();
 
             ClearCachedState();
         }


### PR DESCRIPTION
Reduces unnecessary overhead from releasing command buffers.

![JetBrains Rider 2023-07-03 at 10 37 44](https://github.com/veldrid/veldrid/assets/191335/6edabfff-dfb0-4d6d-a641-cde6eabf780d)

See https://developer.apple.com/documentation/metal/mtlcommandqueue/1508686-commandbuffer, command queue handles this for us. Can be confirmed by adding some stray calls to ` _commandQueue.commandBuffer();` without submitting them (which will correctly deadlock).

![JetBrains Rider 2023-07-03 at 10 37 13](https://github.com/veldrid/veldrid/assets/191335/ec27eb15-9e5e-47b7-9be8-cdc9cc55d56e)
![JetBrains Rider 2023-07-03 at 10 37 30](https://github.com/veldrid/veldrid/assets/191335/a6e6ef12-f806-43d8-bc70-6d878fc6f739)
