### PR TITLE
Request next Metal drawable in `WaitForNextFrameReady` on iOS

### DIFF
--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -249,6 +249,14 @@ namespace Veldrid.MTL
         {
             _frameEndedEvent.Reset();
             _nextFrameReadyEvent?.WaitOne(TimeSpan.FromSeconds(1)); // Should never time out.
+
+            // in iOS, if one frame takes longer than the next V-Sync request, the next frame will be processed immediately rather than being delayed to a subsequent V-Sync request,
+            // therefore we will request the next drawable here as a method of waiting until we're ready to draw the next frame.
+            if (!MetalFeatures.IsMacOS)
+            {
+                MTLSwapchainFramebuffer mtlSwapchainFramebuffer = Util.AssertSubtype<Framebuffer, MTLSwapchainFramebuffer>(_mainSwapchain.Framebuffer);
+                mtlSwapchainFramebuffer.EnsureDrawableAvailable();
+            }
         }
 
         private void OnDisplayLinkCallback()


### PR DESCRIPTION
If a frame takes longer than usual, `CADisplayLink` would process the next immediately rather than waiting for next V-Sync request, and the next frame will get stuck waiting for next drawable until the previous one is presented to the screen and the drawable is free to use for the next frame.

Previously, iOS would wait for next drawable on the first draw call in the frame, specifically in here:

![CleanShot 2023-07-06 at 04 05 40](https://github.com/ppy/veldrid/assets/22781491/993bfb06-178e-48b6-be75-c0d68b06b40e)

But this is bad for the frame time display, as the draw call is classified under the "Work" time frame, therefore we'll see high & incorrect frame times, as can be seen below:

![IMG_6105](https://github.com/ppy/veldrid/assets/22781491/c2dc7b05-9344-4b5d-8fd4-495f9bed17ca)

Now, with this pull request, the time spent on waiting for next drawable will be correctly classified under the "Sleep" time frame, similar to macOS:

![IMG_6104](https://github.com/ppy/veldrid/assets/22781491/90b14aa3-0110-44c7-9772-733a2bcc9b35)
