### PR TITLE
Fix AOT compilation failure on iOS

### DIFF
--- a/src/Veldrid/D3D11/D3D11Swapchain.cs
+++ b/src/Veldrid/D3D11/D3D11Swapchain.cs
@@ -120,10 +120,14 @@ namespace Veldrid.D3D11
                 ? Format.B8G8R8A8_UNorm_SRgb
                 : Format.B8G8R8A8_UNorm;
 
-            using (IDXGIFactory5 dxgiFactory5 = _gd.Adapter.GetParentOrNull<IDXGIFactory5>())
+            // previously we had an extension method ("GetParentOrNull") which makes this read a lot better,
+            // but it resulted in AOT compilation crashes on iOS, therefore we can only do this inline.
+            using (IDXGIFactory5 dxgiFactory5 = (_gd.Adapter.GetParent(out IDXGIFactory5 f).Success ? f : null))
                 _canTear = dxgiFactory5?.PresentAllowTearing == true;
 
-            using (IDXGIFactory3 dxgiFactory3 = _gd.Adapter.GetParentOrNull<IDXGIFactory3>())
+            // previously we had an extension method ("GetParentOrNull") which makes this read a lot better,
+            // but it resulted in AOT compilation crashes on iOS, therefore we can only do this inline.
+            using (IDXGIFactory3 dxgiFactory3 = (_gd.Adapter.GetParent(out IDXGIFactory3 f).Success ? f : null))
                 _canCreateFrameLatencyWaitableObject = dxgiFactory3 != null;
 
             _width = description.Width;
@@ -149,7 +153,10 @@ namespace Veldrid.D3D11
 
             // FlipDiscard is only supported on DXGI 1.4+
             bool canUseFlipDiscard;
-            using (IDXGIFactory4 dxgiFactory4 = _gd.Adapter.GetParentOrNull<IDXGIFactory4>())
+
+            // previously we had an extension method ("GetParentOrNull") which makes this read a lot better,
+            // but it resulted in AOT compilation crashes on iOS, therefore we can only do this inline.
+            using (IDXGIFactory4 dxgiFactory4 = (_gd.Adapter.GetParent(out IDXGIFactory4 f).Success ? f : null))
                 canUseFlipDiscard = dxgiFactory4 != null;
 
             SwapEffect swapEffect = canUseFlipDiscard ? SwapEffect.FlipDiscard : SwapEffect.Discard;

--- a/src/Veldrid/D3D11/D3D11Util.cs
+++ b/src/Veldrid/D3D11/D3D11Util.cs
@@ -6,15 +6,6 @@ namespace Veldrid.D3D11
 {
     internal static class D3D11Util
     {
-        /// <summary>
-        /// Returns the given parent of a <see cref="IDXGIObject"/>, or null if no such object exists.
-        /// </summary>
-        public static T GetParentOrNull<T>(this IDXGIObject dxgiObject) where T : ComObject
-        {
-            // Importantly, this uses the overload with an out value, which itself returns the object.
-            return dxgiObject.GetParent(out T obj).Success ? obj : null;
-        }
-
         public static int ComputeSubresource(uint mipLevel, uint mipLevelCount, uint arrayLayer)
         {
             return (int)((arrayLayer * mipLevelCount) + mipLevel);


### PR DESCRIPTION
Mono AOT compiler started failing with error code 1 or 139 since https://github.com/ppy/veldrid/pull/25, and the cause was defining that extension method specifically. This is nothing interesting because the entire DirectX bindings assembly is generated via weird/ancient methods that blows up iOS AOT compilation in multiple ways.