### PR TITLE
Change Metal fences to rely on GPU-side signals instead

### DIFF
--- a/src/Veldrid.MetalBindings/MTLCommandBuffer.cs
+++ b/src/Veldrid.MetalBindings/MTLCommandBuffer.cs
@@ -32,6 +32,9 @@ namespace Veldrid.MetalBindings
         public void addCompletedHandler(IntPtr block)
             => objc_msgSend(NativePtr, sel_addCompletedHandler, block);
 
+        public void encodeSignalEvent(IntPtr @event, ulong value)
+            => objc_msgSend(NativePtr, sel_encodeSignalEvent, @event, value);
+
         public MTLCommandBufferStatus status => (MTLCommandBufferStatus)uint_objc_msgSend(NativePtr, sel_status);
 
         private static readonly Selector sel_renderCommandEncoderWithDescriptor = "renderCommandEncoderWithDescriptor:";
@@ -41,6 +44,7 @@ namespace Veldrid.MetalBindings
         private static readonly Selector sel_computeCommandEncoder = "computeCommandEncoder";
         private static readonly Selector sel_waitUntilCompleted = "waitUntilCompleted";
         private static readonly Selector sel_addCompletedHandler = "addCompletedHandler:";
+        private static readonly Selector sel_encodeSignalEvent = "encodeSignalEvent:value:";
         private static readonly Selector sel_status = "status";
     }
 }

--- a/src/Veldrid.MetalBindings/MTLDevice.cs
+++ b/src/Veldrid.MetalBindings/MTLDevice.cs
@@ -116,6 +116,9 @@ namespace Veldrid.MetalBindings
         public MTLDepthStencilState newDepthStencilStateWithDescriptor(MTLDepthStencilDescriptor descriptor)
             => objc_msgSend<MTLDepthStencilState>(NativePtr, sel_newDepthStencilStateWithDescriptor, descriptor.NativePtr);
 
+        public MTLSharedEvent newSharedEvent()
+            => objc_msgSend<MTLSharedEvent>(NativePtr, sel_newSharedEvent);
+
         public Bool8 supportsTextureSampleCount(UIntPtr sampleCount)
             => bool8_objc_msgSend(NativePtr, sel_supportsTextureSampleCount, sampleCount);
 
@@ -143,6 +146,7 @@ namespace Veldrid.MetalBindings
         private static readonly Selector sel_newTextureWithDescriptor = "newTextureWithDescriptor:";
         private static readonly Selector sel_newSamplerStateWithDescriptor = "newSamplerStateWithDescriptor:";
         private static readonly Selector sel_newDepthStencilStateWithDescriptor = "newDepthStencilStateWithDescriptor:";
+        private static readonly Selector sel_newSharedEvent = "newSharedEvent";
         private static readonly Selector sel_supportsTextureSampleCount = "supportsTextureSampleCount:";
         private static readonly Selector sel_supportsFeatureSet = "supportsFeatureSet:";
         private static readonly Selector sel_isDepth24Stencil8PixelFormatSupported = "isDepth24Stencil8PixelFormatSupported";

--- a/src/Veldrid.MetalBindings/MTLSharedEvent.cs
+++ b/src/Veldrid.MetalBindings/MTLSharedEvent.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+using static Veldrid.MetalBindings.ObjectiveCRuntime;
+
+namespace Veldrid.MetalBindings
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MTLSharedEvent
+    {
+        public readonly IntPtr NativePtr;
+        public MTLSharedEvent(IntPtr ptr) => NativePtr = ptr;
+
+        public ulong signaledValue
+        {
+            get => objc_msgSend<ulong>(NativePtr, sel_signaledValue);
+            set => objc_msgSend(NativePtr, sel_setSignaledValue, value);
+        }
+
+        private static readonly Selector sel_signaledValue = "signaledValue";
+        private static readonly Selector sel_setSignaledValue = "setSignaledValue:";
+    }
+}

--- a/src/Veldrid.MetalBindings/ObjectiveCRuntime.cs
+++ b/src/Veldrid.MetalBindings/ObjectiveCRuntime.cs
@@ -15,6 +15,8 @@ namespace Veldrid.MetalBindings
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, double a);
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+        public static extern void objc_msgSend(IntPtr receiver, Selector selector, ulong a);
+        [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, CGRect a);
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, IntPtr a, uint b);
@@ -56,6 +58,8 @@ namespace Veldrid.MetalBindings
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, MTLPrimitiveType a, UIntPtr b, MTLIndexType c, IntPtr d, UIntPtr e, UIntPtr f);
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, MTLPrimitiveType a, MTLBuffer b, UIntPtr c);
+        [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+        public static extern void objc_msgSend(IntPtr receiver, Selector selector, IntPtr a, ulong b);
 
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(

--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -46,7 +46,6 @@ namespace Veldrid.MTL
         private readonly List<MTLBuffer> _availableStagingBuffers = new List<MTLBuffer>();
         private readonly Dictionary<MTLCommandBuffer, List<MTLBuffer>> _submittedStagingBuffers = new Dictionary<MTLCommandBuffer, List<MTLBuffer>>();
         private readonly object _submittedCommandsLock = new object();
-        private MTLFence _completionFence;
 
         public MTLCommandBuffer CommandBuffer => _cb;
 
@@ -408,17 +407,8 @@ namespace Veldrid.MTL
             return Util.AssertSubtype<DeviceBuffer, MTLBuffer>(staging);
         }
 
-        public void SetCompletionFence(MTLFence fence)
-        {
-            Debug.Assert(_completionFence == null);
-            _completionFence = fence;
-        }
-
         public void OnCompleted(MTLCommandBuffer cb)
         {
-            _completionFence?.Set();
-            _completionFence = null;
-
             lock (_submittedCommandsLock)
             {
                 if (_submittedStagingBuffers.TryGetValue(cb, out List<MTLBuffer> bufferList))

--- a/src/Veldrid/MTL/MTLFence.cs
+++ b/src/Veldrid/MTL/MTLFence.cs
@@ -1,39 +1,37 @@
-using System;
-using System.Threading;
+using Veldrid.MetalBindings;
 
 namespace Veldrid.MTL
 {
     internal class MTLFence : Fence
     {
-        private readonly ManualResetEvent _mre;
+        public const ulong NOT_SIGNALED = 0;
+        public const ulong SIGNALED = 1;
+
+        private MTLSharedEvent _event;
         private bool _disposed;
 
-        public MTLFence(bool signaled)
+        public MTLFence(bool signaled, MTLGraphicsDevice gd)
         {
-            _mre = new ManualResetEvent(signaled);
+            _event = gd.Device.newSharedEvent();
+
+            // _event.signaledValue = signaled ? SIGNALED : NOT_SIGNALED;
         }
 
         public override string Name { get; set; }
-        public ManualResetEvent ResetEvent => _mre;
 
-        public void Set() => _mre.Set();
-        public override void Reset() => _mre.Reset();
-        public override bool Signaled => _mre.WaitOne(0);
+        public override void Reset() => _event.signaledValue = NOT_SIGNALED;
+        public MTLSharedEvent SharedEvent => _event;
+
+        public override bool Signaled => _event.signaledValue == SIGNALED;
         public override bool IsDisposed => _disposed;
 
         public override void Dispose()
         {
             if (!_disposed)
             {
-                _mre.Dispose();
+                ObjectiveCRuntime.release(_event.NativePtr);
                 _disposed = true;
             }
-        }
-
-        internal bool Wait(ulong nanosecondTimeout)
-        {
-            ulong timeout = Math.Min(int.MaxValue, nanosecondTimeout / 1_000_000);
-            return _mre.WaitOne((int)timeout);
         }
     }
 }

--- a/src/Veldrid/MTL/MTLFence.cs
+++ b/src/Veldrid/MTL/MTLFence.cs
@@ -13,8 +13,6 @@ namespace Veldrid.MTL
         public MTLFence(bool signaled, MTLGraphicsDevice gd)
         {
             _event = gd.Device.newSharedEvent();
-
-            // _event.signaledValue = signaled ? SIGNALED : NOT_SIGNALED;
         }
 
         public override string Name { get; set; }

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -234,10 +234,12 @@ namespace Veldrid.MTL
         private protected override void SubmitCommandsCore(CommandList commandList, Fence fence)
         {
             MTLCommandList mtlCL = Util.AssertSubtype<CommandList, MTLCommandList>(commandList);
-            MTLFence mtlFence = Util.AssertSubtype<Fence, MTLFence>(fence);
 
-            if (mtlFence != null)
+            if (fence != null)
+            {
+                MTLFence mtlFence = Util.AssertSubtype<Fence, MTLFence>(fence);
                 mtlCL.CommandBuffer.encodeSignalEvent(mtlFence.SharedEvent.NativePtr, MTLFence.SIGNALED);
+            }
 
             mtlCL.CommandBuffer.addCompletedHandler(_completionBlockLiteral);
 

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -531,12 +531,12 @@ namespace Veldrid.MTL
         }
 
         public override bool WaitForFence(Fence fence, ulong nanosecondTimeout) =>
-            throw new NotImplementedException("Fences are now handled by GPU, this requires establishing a notification listener for the underlying event and waiting for a signal.");
+            // this can be supported by setting up a MTLSharedEventListener and waiting for a signal by the GPU.
+            throw new NotImplementedException("Waiting for fences on Metal is not implemented yet.");
 
-        public override bool WaitForFences(Fence[] fences, bool waitAll, ulong nanosecondTimeout)
-        {
-            throw new NotImplementedException("Fences are now handled by GPU, this requires establishing a notification listener for the underlying event and waiting for a signal.");
-        }
+        public override bool WaitForFences(Fence[] fences, bool waitAll, ulong nanosecondTimeout) =>
+            // this can be supported by setting up a MTLSharedEventListener and waiting for a signal by the GPU.
+            throw new NotImplementedException("Waiting for fences on Metal is not implemented yet.");
 
         public override void ResetFence(Fence fence)
         {

--- a/src/Veldrid/MTL/MTLResourceFactory.cs
+++ b/src/Veldrid/MTL/MTLResourceFactory.cs
@@ -77,7 +77,7 @@ namespace Veldrid.MTL
 
         public override Fence CreateFence(bool signaled)
         {
-            return new MTLFence(signaled);
+            return new MTLFence(signaled, _gd);
         }
 
         public override Swapchain CreateSwapchain(ref SwapchainDescription description)


### PR DESCRIPTION
Dependency for getting rid of all the mutex locks surrounding `MTLCommandBuffer` completion handler, and potentially getting rid of the completion handler altogether.

In Metal, there is an object which can be accessed & updated by both the CPU and the GPU, and this PR relies on that object to use for implementing fences instead. Works pretty efficiently, and on a 10 second run on sample game, there's about 12ms spent on reading the signal value by the CPU:

![CleanShot 2023-07-09 at 09 29 55](https://github.com/ppy/veldrid/assets/22781491/844e2a93-6b3b-478a-acd9-932bbc7e7ce6)
