### PR TITLE
Remove Metal staging buffers cache to avoid lock contention overhead in command buffer completion handler

### DIFF
--- a/src/Veldrid.MetalBindings/MTLCommandBuffer.cs
+++ b/src/Veldrid.MetalBindings/MTLCommandBuffer.cs
@@ -32,6 +32,9 @@ namespace Veldrid.MetalBindings
         public void addCompletedHandler(IntPtr block)
             => objc_msgSend(NativePtr, sel_addCompletedHandler, block);
 
+        public void encodeSignalEvent(IntPtr @event, ulong value)
+            => objc_msgSend(NativePtr, sel_encodeSignalEvent, @event, value);
+
         public MTLCommandBufferStatus status => (MTLCommandBufferStatus)uint_objc_msgSend(NativePtr, sel_status);
 
         private static readonly Selector sel_renderCommandEncoderWithDescriptor = "renderCommandEncoderWithDescriptor:";
@@ -41,6 +44,7 @@ namespace Veldrid.MetalBindings
         private static readonly Selector sel_computeCommandEncoder = "computeCommandEncoder";
         private static readonly Selector sel_waitUntilCompleted = "waitUntilCompleted";
         private static readonly Selector sel_addCompletedHandler = "addCompletedHandler:";
+        private static readonly Selector sel_encodeSignalEvent = "encodeSignalEvent:value:";
         private static readonly Selector sel_status = "status";
     }
 }

--- a/src/Veldrid.MetalBindings/MTLDevice.cs
+++ b/src/Veldrid.MetalBindings/MTLDevice.cs
@@ -116,6 +116,9 @@ namespace Veldrid.MetalBindings
         public MTLDepthStencilState newDepthStencilStateWithDescriptor(MTLDepthStencilDescriptor descriptor)
             => objc_msgSend<MTLDepthStencilState>(NativePtr, sel_newDepthStencilStateWithDescriptor, descriptor.NativePtr);
 
+        public MTLSharedEvent newSharedEvent()
+            => objc_msgSend<MTLSharedEvent>(NativePtr, sel_newSharedEvent);
+
         public Bool8 supportsTextureSampleCount(UIntPtr sampleCount)
             => bool8_objc_msgSend(NativePtr, sel_supportsTextureSampleCount, sampleCount);
 
@@ -143,6 +146,7 @@ namespace Veldrid.MetalBindings
         private static readonly Selector sel_newTextureWithDescriptor = "newTextureWithDescriptor:";
         private static readonly Selector sel_newSamplerStateWithDescriptor = "newSamplerStateWithDescriptor:";
         private static readonly Selector sel_newDepthStencilStateWithDescriptor = "newDepthStencilStateWithDescriptor:";
+        private static readonly Selector sel_newSharedEvent = "newSharedEvent";
         private static readonly Selector sel_supportsTextureSampleCount = "supportsTextureSampleCount:";
         private static readonly Selector sel_supportsFeatureSet = "supportsFeatureSet:";
         private static readonly Selector sel_isDepth24Stencil8PixelFormatSupported = "isDepth24Stencil8PixelFormatSupported";

--- a/src/Veldrid.MetalBindings/MTLSharedEvent.cs
+++ b/src/Veldrid.MetalBindings/MTLSharedEvent.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+using static Veldrid.MetalBindings.ObjectiveCRuntime;
+
+namespace Veldrid.MetalBindings
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MTLSharedEvent
+    {
+        public readonly IntPtr NativePtr;
+        public MTLSharedEvent(IntPtr ptr) => NativePtr = ptr;
+
+        public ulong signaledValue
+        {
+            get => objc_msgSend<ulong>(NativePtr, sel_signaledValue);
+            set => objc_msgSend(NativePtr, sel_setSignaledValue, value);
+        }
+
+        private static readonly Selector sel_signaledValue = "signaledValue";
+        private static readonly Selector sel_setSignaledValue = "setSignaledValue:";
+    }
+}

--- a/src/Veldrid.MetalBindings/ObjectiveCRuntime.cs
+++ b/src/Veldrid.MetalBindings/ObjectiveCRuntime.cs
@@ -15,6 +15,8 @@ namespace Veldrid.MetalBindings
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, double a);
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+        public static extern void objc_msgSend(IntPtr receiver, Selector selector, ulong a);
+        [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, CGRect a);
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, IntPtr a, uint b);
@@ -56,6 +58,8 @@ namespace Veldrid.MetalBindings
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, MTLPrimitiveType a, UIntPtr b, MTLIndexType c, IntPtr d, UIntPtr e, UIntPtr f);
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, MTLPrimitiveType a, MTLBuffer b, UIntPtr c);
+        [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+        public static extern void objc_msgSend(IntPtr receiver, Selector selector, IntPtr a, ulong b);
 
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(

--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -46,7 +46,6 @@ namespace Veldrid.MTL
         private readonly List<MTLBuffer> _availableStagingBuffers = new List<MTLBuffer>();
         private readonly Dictionary<MTLCommandBuffer, List<MTLBuffer>> _submittedStagingBuffers = new Dictionary<MTLCommandBuffer, List<MTLBuffer>>();
         private readonly object _submittedCommandsLock = new object();
-        private MTLFence _completionFence;
 
         public MTLCommandBuffer CommandBuffer => _cb;
 
@@ -408,17 +407,8 @@ namespace Veldrid.MTL
             return Util.AssertSubtype<DeviceBuffer, MTLBuffer>(staging);
         }
 
-        public void SetCompletionFence(MTLFence fence)
-        {
-            Debug.Assert(_completionFence == null);
-            _completionFence = fence;
-        }
-
         public void OnCompleted(MTLCommandBuffer cb)
         {
-            _completionFence?.Set();
-            _completionFence = null;
-
             lock (_submittedCommandsLock)
             {
                 if (_submittedStagingBuffers.TryGetValue(cb, out List<MTLBuffer> bufferList))

--- a/src/Veldrid/MTL/MTLFence.cs
+++ b/src/Veldrid/MTL/MTLFence.cs
@@ -1,39 +1,37 @@
-using System;
-using System.Threading;
+using Veldrid.MetalBindings;
 
 namespace Veldrid.MTL
 {
     internal class MTLFence : Fence
     {
-        private readonly ManualResetEvent _mre;
+        public const ulong NOT_SIGNALED = 0;
+        public const ulong SIGNALED = 1;
+
+        private MTLSharedEvent _event;
         private bool _disposed;
 
-        public MTLFence(bool signaled)
+        public MTLFence(bool signaled, MTLGraphicsDevice gd)
         {
-            _mre = new ManualResetEvent(signaled);
+            _event = gd.Device.newSharedEvent();
+
+            // _event.signaledValue = signaled ? SIGNALED : NOT_SIGNALED;
         }
 
         public override string Name { get; set; }
-        public ManualResetEvent ResetEvent => _mre;
 
-        public void Set() => _mre.Set();
-        public override void Reset() => _mre.Reset();
-        public override bool Signaled => _mre.WaitOne(0);
+        public override void Reset() => _event.signaledValue = NOT_SIGNALED;
+        public MTLSharedEvent SharedEvent => _event;
+
+        public override bool Signaled => _event.signaledValue == SIGNALED;
         public override bool IsDisposed => _disposed;
 
         public override void Dispose()
         {
             if (!_disposed)
             {
-                _mre.Dispose();
+                ObjectiveCRuntime.release(_event.NativePtr);
                 _disposed = true;
             }
-        }
-
-        internal bool Wait(ulong nanosecondTimeout)
-        {
-            ulong timeout = Math.Min(int.MaxValue, nanosecondTimeout / 1_000_000);
-            return _mre.WaitOne((int)timeout);
         }
     }
 }

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -25,13 +25,6 @@ namespace Veldrid.MTL
         private readonly bool[] _supportedSampleCounts;
         private BackendInfoMetal _metalInfo;
 
-        private readonly object _submittedCommandsLock = new object();
-        private readonly Dictionary<MTLCommandBuffer, MTLCommandList> _submittedCLs = new Dictionary<MTLCommandBuffer, MTLCommandList>();
-        private MTLCommandBuffer _latestSubmittedCB;
-
-        private readonly object _resetEventsLock = new object();
-        private readonly List<ManualResetEvent[]> _resetEvents = new List<ManualResetEvent[]>();
-
         private const string UnalignedBufferCopyPipelineMacOSName = "MTL_UnalignedBufferCopy_macOS";
         private const string UnalignedBufferCopyPipelineiOSName = "MTL_UnalignedBufferCopy_iOS";
         private readonly object _unalignedBufferCopyPipelineLock = new object();
@@ -201,22 +194,7 @@ namespace Veldrid.MTL
 
         public override GraphicsDeviceFeatures Features { get; }
 
-        private void OnCommandBufferCompleted(IntPtr block, MTLCommandBuffer cb)
-        {
-            lock (_submittedCommandsLock)
-            {
-                MTLCommandList cl = _submittedCLs[cb];
-                _submittedCLs.Remove(cb);
-                cl.OnCompleted(cb);
-
-                if (_latestSubmittedCB.NativePtr == cb.NativePtr)
-                {
-                    _latestSubmittedCB = default(MTLCommandBuffer);
-                }
-            }
-
-            ObjectiveCRuntime.release(cb.NativePtr);
-        }
+        private void OnCommandBufferCompleted(IntPtr block, MTLCommandBuffer cb) => ObjectiveCRuntime.release(cb.NativePtr);
 
         // Xamarin AOT requires native callbacks be static.
         [MonoPInvokeCallback(typeof(MTLCommandBufferHandler))]
@@ -240,12 +218,7 @@ namespace Veldrid.MTL
                 mtlCL.CommandBuffer.encodeSignalEvent(mtlFence.SharedEvent.NativePtr, MTLFence.SIGNALED);
 
             mtlCL.CommandBuffer.addCompletedHandler(_completionBlockLiteral);
-
-            lock (_submittedCommandsLock)
-            {
-                _submittedCLs.Add(mtlCL.CommandBuffer, mtlCL);
-                _latestSubmittedCB = mtlCL.Commit();
-            }
+            mtlCL.Commit();
         }
 
         private protected override void WaitForNextFrameReadyCore()
@@ -438,20 +411,8 @@ namespace Veldrid.MTL
 
         private protected override void WaitForIdleCore()
         {
-            MTLCommandBuffer lastCB = default(MTLCommandBuffer);
-
-            lock (_submittedCommandsLock)
-            {
-                lastCB = _latestSubmittedCB;
-                ObjectiveCRuntime.retain(lastCB.NativePtr);
-            }
-
-            if (lastCB.NativePtr != IntPtr.Zero && lastCB.status != MTLCommandBufferStatus.Completed)
-            {
-                lastCB.waitUntilCompleted();
-            }
-
-            ObjectiveCRuntime.release(lastCB.NativePtr);
+            // todo: this may not work as it's not guaranteed that _latestSubmittedCB hasn't already been released yet.
+            throw new NotSupportedException("WaitForIdle is not supported on Metal currently. Use a fence and spin on the signal (because WaitForFence is also unsupported).");
         }
 
         protected override MappedResource MapCore(MappableResource resource, MapMode mode, uint subresource)

--- a/src/Veldrid/MTL/MTLResourceFactory.cs
+++ b/src/Veldrid/MTL/MTLResourceFactory.cs
@@ -77,7 +77,7 @@ namespace Veldrid.MTL
 
         public override Fence CreateFence(bool signaled)
         {
-            return new MTLFence(signaled);
+            return new MTLFence(signaled, _gd);
         }
 
         public override Swapchain CreateSwapchain(ref SwapchainDescription description)


### PR DESCRIPTION
- [x] Depends on #30 

The caching will be added back at an o!f level instead.

Before:
  ![CleanShot 2023-07-09 at 09 22 04](https://github.com/ppy/veldrid/assets/22781491/264724e8-cbd4-4e2b-9222-2482ce1e4cbb)

After:
  ![CleanShot 2023-07-09 at 09 22 15](https://github.com/ppy/veldrid/assets/22781491/a4f6361c-88b4-468b-8f01-02dc76293990)

(all on just a 10 second run of sample game with nothing extra displayed)