### PR TITLE
Mark SSBOs as supported only with feature level >= 11_0

### DIFF
--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -192,7 +192,7 @@ namespace Veldrid.D3D11
                 depthClipDisable: true,
                 texture1D: true,
                 independentBlend: true,
-                structuredBuffer: true,
+                structuredBuffer: _device.FeatureLevel >= Vortice.Direct3D.FeatureLevel.Level_11_0,
                 subsetTextureView: true,
                 commandListDebugMarkers: _device.FeatureLevel >= Vortice.Direct3D.FeatureLevel.Level_11_1,
                 bufferRangeBinding: _device.FeatureLevel >= Vortice.Direct3D.FeatureLevel.Level_11_1,


### PR DESCRIPTION
Upstream only supports devices with feature level >= 11_0 (https://github.com/veldrid/veldrid/blob/20821757d1e88e72219958c9e4e79edfb955f893/src/Veldrid/D3D11/D3D11GraphicsDevice.cs#L89-L123).

This fork also supports feature level 10_0, but this feature level doesn't support SSBOs.