### PR TITLE
Don't rebind MTL buffers when only changing offsets

### DIFF
--- a/src/Veldrid.MetalBindings/MTLRenderCommandEncoder.cs
+++ b/src/Veldrid.MetalBindings/MTLRenderCommandEncoder.cs
@@ -20,9 +20,19 @@ namespace Veldrid.MetalBindings
                 offset,
                 index);
 
+        public void setVertexBufferOffset( UIntPtr offset, UIntPtr index)
+            => objc_msgSend(NativePtr, sel_setVertexBufferOffset,
+                offset,
+                index);
+
         public void setFragmentBuffer(MTLBuffer buffer, UIntPtr offset, UIntPtr index)
             => objc_msgSend(NativePtr, sel_setFragmentBuffer,
                 buffer.NativePtr,
+                offset,
+                index);
+
+        public void setFragmentBufferOffset(UIntPtr offset, UIntPtr index)
+            => objc_msgSend(NativePtr, sel_setFragmentBufferOffset,
                 offset,
                 index);
 
@@ -142,7 +152,9 @@ namespace Veldrid.MetalBindings
 
         private static readonly Selector sel_setRenderPipelineState = "setRenderPipelineState:";
         private static readonly Selector sel_setVertexBuffer = "setVertexBuffer:offset:atIndex:";
+        private static readonly Selector sel_setVertexBufferOffset = "setVertexBufferOffset:atIndex:";
         private static readonly Selector sel_setFragmentBuffer = "setFragmentBuffer:offset:atIndex:";
+        private static readonly Selector sel_setFragmentBufferOffset = "setFragmentBufferOffset:atIndex:";
         private static readonly Selector sel_setVertexTexture = "setVertexTexture:atIndex:";
         private static readonly Selector sel_setFragmentTexture = "setFragmentTexture:atIndex:";
         private static readonly Selector sel_setVertexSamplerState = "setVertexSamplerState:atIndex:";

--- a/src/Veldrid.MetalBindings/ObjectiveCRuntime.cs
+++ b/src/Veldrid.MetalBindings/ObjectiveCRuntime.cs
@@ -31,6 +31,8 @@ namespace Veldrid.MetalBindings
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, IntPtr a, UIntPtr b, UIntPtr c);
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+        public static extern void objc_msgSend(IntPtr receiver, Selector selector, UIntPtr b, UIntPtr c);
+        [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, void* a, UIntPtr b, UIntPtr c);
         [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
         public static extern void objc_msgSend(IntPtr receiver, Selector selector, MTLPrimitiveType a, UIntPtr b, UIntPtr c, UIntPtr d, UIntPtr e);


### PR DESCRIPTION
Use [`setVertexBufferOffset:atIndex:`](https://developer.apple.com/documentation/metal/mtlrendercommandencoder/1515433-setvertexbufferoffset?language=objc) and [`setFragmentBufferOffset:atIndex:`](https://developer.apple.com/documentation/metal/mtlrendercommandencoder/1515917-setfragmentbufferoffset?language=objc) when only changing the bound buffer's offset. These are documented to be more efficient.

Of note, osu! currently doesn't make use of this, but I have local changes that trigger warnings related to this in Xcode's profiler. Performance gain is minimal-to-none (at least on `osx-arm64`).

Also, I'm putting these changes here for now because we apparently have several other changes that have yet to be merged into upstream, which this is dependent upon. That probably needs to change.