### PR TITLE
Fix `_nextFrameReadyEvent` not initialised before display callback

### DIFF
--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -44,7 +44,7 @@ namespace Veldrid.MTL
         private readonly IntPtr _completionBlockLiteral;
 
         private readonly IMTLDisplayLink _displayLink;
-        private readonly AutoResetEvent _nextFrameReadyEvent = new AutoResetEvent(true);
+        private readonly AutoResetEvent _nextFrameReadyEvent;
         private readonly EventWaitHandle _frameEndedEvent = new EventWaitHandle(true, EventResetMode.ManualReset);
 
         public MTLDevice Device => _device;
@@ -126,7 +126,10 @@ namespace Veldrid.MTL
             }
 
             if (_displayLink != null)
+            {
+                _nextFrameReadyEvent = new AutoResetEvent(true);
                 _displayLink.Callback += OnDisplayLinkCallback;
+            }
 
             _completionHandlerFuncPtr = Marshal.GetFunctionPointerForDelegate<MTLCommandBufferHandler>(_completionHandler);
             _completionBlockDescriptor = Marshal.AllocHGlobal(Unsafe.SizeOf<BlockDescriptor>());

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -44,7 +44,7 @@ namespace Veldrid.MTL
         private readonly IntPtr _completionBlockLiteral;
 
         private readonly IMTLDisplayLink _displayLink;
-        private readonly AutoResetEvent _nextFrameReadyEvent;
+        private readonly AutoResetEvent _nextFrameReadyEvent = new AutoResetEvent(true);
         private readonly EventWaitHandle _frameEndedEvent = new EventWaitHandle(true, EventResetMode.ManualReset);
 
         public MTLDevice Device => _device;
@@ -126,10 +126,7 @@ namespace Veldrid.MTL
             }
 
             if (_displayLink != null)
-            {
                 _displayLink.Callback += OnDisplayLinkCallback;
-                _nextFrameReadyEvent = new AutoResetEvent(true);
-            }
 
             _completionHandlerFuncPtr = Marshal.GetFunctionPointerForDelegate<MTLCommandBufferHandler>(_completionHandler);
             _completionBlockDescriptor = Marshal.AllocHGlobal(Unsafe.SizeOf<BlockDescriptor>());


### PR DESCRIPTION
Reported in [discord](https://discord.com/channels/188630481301012481/589331078574112768/1215169087727214622).