### PR TITLE
Fix MTL completion fences discarded by newer CBs

### DIFF
--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -430,7 +430,7 @@ namespace Veldrid.MTL
         {
             lock (_submittedCommandsLock)
             {
-                Debug.Assert(_completionFences.ContainsKey(cb));
+                Debug.Assert(!_completionFences.ContainsKey(cb));
                 _completionFences[cb] = fence;
             }
         }

--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -47,7 +47,7 @@ namespace Veldrid.MTL
         private readonly List<MTLBuffer> _availableStagingBuffers = new List<MTLBuffer>();
         private readonly Dictionary<MTLCommandBuffer, List<MTLBuffer>> _submittedStagingBuffers = new Dictionary<MTLCommandBuffer, List<MTLBuffer>>();
         private readonly object _submittedCommandsLock = new object();
-        private MTLFence _completionFence;
+        private readonly Dictionary<MTLCommandBuffer, MTLFence> _completionFences = new Dictionary<MTLCommandBuffer, MTLFence>();
 
         public MTLCommandBuffer CommandBuffer => _cb;
 
@@ -426,19 +426,25 @@ namespace Veldrid.MTL
             return Util.AssertSubtype<DeviceBuffer, MTLBuffer>(staging);
         }
 
-        public void SetCompletionFence(MTLFence fence)
+        public void SetCompletionFence(MTLCommandBuffer cb, MTLFence fence)
         {
-            Debug.Assert(_completionFence == null);
-            _completionFence = fence;
+            lock (_submittedCommandsLock)
+            {
+                Debug.Assert(_completionFences.ContainsKey(cb));
+                _completionFences[cb] = fence;
+            }
         }
 
         public void OnCompleted(MTLCommandBuffer cb)
         {
-            _completionFence?.Set();
-            _completionFence = null;
-
             lock (_submittedCommandsLock)
             {
+                if (_completionFences.TryGetValue(cb, out MTLFence completionFence))
+                {
+                    completionFence.Set();
+                    _completionFences.Remove(cb);
+                }
+
                 if (_submittedStagingBuffers.TryGetValue(cb, out List<MTLBuffer> bufferList))
                 {
                     _availableStagingBuffers.AddRange(bufferList);

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -237,7 +237,7 @@ namespace Veldrid.MTL
             {
                 if (fence != null)
                 {
-                    mtlCL.SetCompletionFence(Util.AssertSubtype<Fence, MTLFence>(fence));
+                    mtlCL.SetCompletionFence(mtlCL.CommandBuffer, Util.AssertSubtype<Fence, MTLFence>(fence));
                 }
 
                 _submittedCLs.Add(mtlCL.CommandBuffer, mtlCL);


### PR DESCRIPTION
Command buffers execution is started in order, but is not guaranteed to complete in order.