### PR TITLE
Work around D3D11 texture pointer getting lost before disposal

### DIFF
--- a/src/Veldrid/D3D11/D3D11Texture.cs
+++ b/src/Veldrid/D3D11/D3D11Texture.cs
@@ -145,6 +145,9 @@ namespace Veldrid.D3D11
 
                 DeviceTexture = device.CreateTexture3D(desc3D);
             }
+
+            // See: https://github.com/ppy/veldrid/issues/53
+            GC.SuppressFinalize(DeviceTexture);
         }
 
         public D3D11Texture(ID3D11Texture2D existingTexture, TextureType type, PixelFormat format)
@@ -167,6 +170,9 @@ namespace Veldrid.D3D11
                 format,
                 (Usage & TextureUsage.DepthStencil) == TextureUsage.DepthStencil);
             TypelessDxgiFormat = D3D11Formats.GetTypelessFormat(DxgiFormat);
+
+            // See: https://github.com/ppy/veldrid/issues/53
+            GC.SuppressFinalize(DeviceTexture);
         }
 
         private protected override TextureView CreateFullTextureView(GraphicsDevice gd)

--- a/src/Veldrid/D3D11/D3D11TextureView.cs
+++ b/src/Veldrid/D3D11/D3D11TextureView.cs
@@ -37,7 +37,11 @@ namespace Veldrid.D3D11
                 description.BaseArrayLayer,
                 description.ArrayLayers,
                 Format);
+
             ShaderResourceView = device.CreateShaderResourceView(d3dTex.DeviceTexture, srvDesc);
+
+            // See: https://github.com/ppy/veldrid/issues/53
+            GC.SuppressFinalize(ShaderResourceView);
 
             if ((d3dTex.Usage & TextureUsage.Storage) == TextureUsage.Storage)
             {
@@ -93,6 +97,9 @@ namespace Veldrid.D3D11
                 }
 
                 UnorderedAccessView = device.CreateUnorderedAccessView(d3dTex.DeviceTexture, uavDesc);
+
+                // See: https://github.com/ppy/veldrid/issues/53
+                GC.SuppressFinalize(UnorderedAccessView);
             }
         }
 


### PR DESCRIPTION
The easy-difficulty solution from https://github.com/ppy/veldrid/issues/53

osu!framework test:
```csharp
// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
// See the LICENCE file in the repository root for full licence text.

using System;
using NUnit.Framework;
using osu.Framework.Allocation;
using osu.Framework.Graphics;
using osu.Framework.Graphics.Containers;
using osu.Framework.Graphics.Rendering;
using osu.Framework.Graphics.Sprites;
using osu.Framework.Graphics.Textures;
using osuTK;
using osuTK.Graphics;

namespace osu.Framework.Tests.Visual.Graphics
{
    /// <summary>
    /// Continuously allocates graphics objects and leaves it up to the finalizer to clean them up.
    /// </summary>
    public partial class TestSceneResourceFinalisationStressTest : FrameworkTestScene
    {
        private Drawable? lastConsumer;
        private Func<Drawable>? createConsumer;
        private int counter;

        [Test]
        public void TestTextureConsumer()
        {
            AddStep("enable texture consumer", () => createConsumer = () => new TextureConsumer());
        }

        protected override void Update()
        {
            base.Update();

            if (lastConsumer != null)
            {
                // It's important to not dispose and leave it up to the finalizer.
                Remove(lastConsumer, false);

                if (++counter % 100 == 0)
                {
                    GC.Collect();
                    GC.WaitForPendingFinalizers();
                }
            }

            if (createConsumer != null)
                Add(lastConsumer = createConsumer());
        }

        private partial class TextureConsumer : CompositeDrawable
        {
            private Sprite sprite = null!;

            public TextureConsumer()
            {
                Size = new Vector2(100);
                Anchor = Anchor.Centre;
                Origin = Anchor.Centre;
            }

            [BackgroundDependencyLoader]
            private void load(IRenderer renderer)
            {
                InternalChild = sprite = new Sprite
                {
                    RelativeSizeAxes = Axes.Both,
                    Texture = renderer.CreateTexture(512, 512, true, initialisationColour: Color4.Red),
                };

                sprite.Texture.SetData(new TextureUpload());
            }
        }
    }
}
```