### PR TITLE
Remove per-frame texture allocation in Metal swapchain

### DIFF
--- a/src/Veldrid/MTL/MTLSwapchainFramebuffer.cs
+++ b/src/Veldrid/MTL/MTLSwapchainFramebuffer.cs
@@ -18,10 +18,10 @@ namespace Veldrid.MTL
         private readonly PixelFormat colorFormat;
 
         private readonly PixelFormat? depthFormat;
-        private MtlTexture colorTexture;
+        private readonly MtlSwapchainTexture colorTexture = new MtlSwapchainTexture();
         private MtlTexture depthTexture;
 
-        private FramebufferAttachment[] colorTargets;
+        private readonly FramebufferAttachment[] colorTargets;
         private FramebufferAttachment? depthTarget;
 
         public MtlSwapchainFramebuffer(
@@ -44,6 +44,8 @@ namespace Veldrid.MTL
 
             var colorAttachment = new OutputAttachmentDescription(colorFormat);
 
+            colorTargets = new[] { new FramebufferAttachment(colorTexture, 0) };
+
             OutputDescription = new OutputDescription(depthAttachment, colorAttachment);
         }
 
@@ -59,8 +61,7 @@ namespace Veldrid.MTL
 
         public void UpdateTextures(CAMetalDrawable drawable, CGSize size)
         {
-            colorTexture = new MtlTexture(drawable, size, colorFormat);
-            colorTargets = new[] { new FramebufferAttachment(colorTexture, 0) };
+            colorTexture.SetDrawable(drawable, size, colorFormat);
 
             if (depthFormat.HasValue && (size.width != depthTexture?.Width || size.height != depthTexture?.Height))
                 recreateDepthTexture((uint)size.width, (uint)size.height);

--- a/src/Veldrid/MTL/MTLSwapchainTexture.cs
+++ b/src/Veldrid/MTL/MTLSwapchainTexture.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Veldrid.MetalBindings;
+
+namespace Veldrid.MTL
+{
+    internal class MtlSwapchainTexture : MtlTexture
+    {
+        public override MTLTexture DeviceTexture => deviceTexture;
+
+        public override uint Width => width;
+
+        public override uint Height => height;
+
+        public override uint Depth => 1;
+
+        public override uint ArrayLayers => 1;
+
+        public override uint MipLevels => 1;
+
+        public override TextureUsage Usage => TextureUsage.RenderTarget;
+
+        public override TextureType Type => TextureType.Texture2D;
+
+        public override TextureSampleCount SampleCount => TextureSampleCount.Count1;
+
+        public override MTLPixelFormat MtlPixelFormat => mtlPixelFormat;
+
+        public override MTLTextureType MtlTextureType => MTLTextureType.Type2D;
+
+        private MTLTexture deviceTexture;
+        private uint width;
+        private uint height;
+        private MTLPixelFormat mtlPixelFormat;
+
+        public void SetDrawable(CAMetalDrawable drawable, CGSize size, PixelFormat format)
+        {
+            deviceTexture = drawable.texture;
+            width = (uint)size.width;
+            height = (uint)size.height;
+            mtlPixelFormat = MtlFormats.VdToMtlPixelFormat(Format, false);
+        }
+    }
+}

--- a/src/Veldrid/MTL/MTLTexture.cs
+++ b/src/Veldrid/MTL/MTLTexture.cs
@@ -128,23 +128,6 @@ namespace Veldrid.MTL
                 (Usage & TextureUsage.Cubemap) != 0);
         }
 
-        public MtlTexture(CAMetalDrawable drawable, CGSize size, PixelFormat format)
-        {
-            DeviceTexture = drawable.texture;
-            Width = (uint)size.width;
-            Height = (uint)size.height;
-            Depth = 1;
-            ArrayLayers = 1;
-            MipLevels = 1;
-            Format = format;
-            Usage = TextureUsage.RenderTarget;
-            Type = TextureType.Texture2D;
-            SampleCount = TextureSampleCount.Count1;
-
-            MtlPixelFormat = MtlFormats.VdToMtlPixelFormat(Format, false);
-            MtlTextureType = MTLTextureType.Type2D;
-        }
-
         protected MtlTexture()
         {
         }

--- a/src/Veldrid/MTL/MTLTexture.cs
+++ b/src/Veldrid/MTL/MTLTexture.cs
@@ -8,7 +8,7 @@ namespace Veldrid.MTL
         /// <summary>
         ///     The native MTLTexture object. This property is only valid for non-staging Textures.
         /// </summary>
-        public MTLTexture DeviceTexture { get; }
+        public virtual MTLTexture DeviceTexture { get; }
 
         /// <summary>
         ///     The staging MTLBuffer object. This property is only valid for staging Textures.
@@ -33,8 +33,8 @@ namespace Veldrid.MTL
 
         public override TextureSampleCount SampleCount { get; }
         public override bool IsDisposed => disposed;
-        public MTLPixelFormat MtlPixelFormat { get; }
-        public MTLTextureType MtlTextureType { get; }
+        public virtual MTLPixelFormat MtlPixelFormat { get; }
+        public virtual MTLTextureType MtlTextureType { get; }
         public MTLStorageMode MtlStorageMode { get; }
 
         public unsafe void* StagingBufferPointer { get; private set; }
@@ -143,6 +143,10 @@ namespace Veldrid.MTL
 
             MtlPixelFormat = MtlFormats.VdToMtlPixelFormat(Format, false);
             MtlTextureType = MTLTextureType.Type2D;
+        }
+
+        protected MtlTexture()
+        {
         }
 
         internal uint GetSubresourceSize(uint mipLevel, uint arrayLayer)


### PR DESCRIPTION
Profiling over around 30s in `TestSceneActiveState`:

| Before | After |
| --- | --- |
|<img width="832" alt="image" src="https://github.com/user-attachments/assets/05807518-e860-4d9e-b60d-8fa117cd016d"> | <img width="834" alt="image" src="https://github.com/user-attachments/assets/9097b903-9e01-412c-aa6e-827a0a6f661e"> |


