### PR TITLE
Remove use of AsRef(AsPointer(ref source)) pattern

### DIFF
--- a/src/Veldrid/CommandList.cs
+++ b/src/Veldrid/CommandList.cs
@@ -694,8 +694,7 @@ namespace Veldrid
             uint bufferOffsetInBytes,
             T source) where T : unmanaged
         {
-            ref byte sourceByteRef = ref Unsafe.AsRef<byte>(Unsafe.AsPointer(ref source));
-            fixed (byte* ptr = &sourceByteRef) UpdateBuffer(buffer, bufferOffsetInBytes, (IntPtr)ptr, (uint)sizeof(T));
+            UpdateBuffer(buffer, bufferOffsetInBytes, (IntPtr)(&source), (uint)sizeof(T));
         }
 
         /// <summary>
@@ -714,8 +713,7 @@ namespace Veldrid
             uint bufferOffsetInBytes,
             ref T source) where T : unmanaged
         {
-            ref byte sourceByteRef = ref Unsafe.AsRef<byte>(Unsafe.AsPointer(ref source));
-            fixed (byte* ptr = &sourceByteRef) UpdateBuffer(buffer, bufferOffsetInBytes, (IntPtr)ptr, Util.USizeOf<T>());
+            fixed (T* ptr = &source) UpdateBuffer(buffer, bufferOffsetInBytes, (IntPtr)ptr, Util.USizeOf<T>());
         }
 
         /// <summary>
@@ -736,8 +734,7 @@ namespace Veldrid
             ref T source,
             uint sizeInBytes) where T : unmanaged
         {
-            ref byte sourceByteRef = ref Unsafe.AsRef<byte>(Unsafe.AsPointer(ref source));
-            fixed (byte* ptr = &sourceByteRef) UpdateBuffer(buffer, bufferOffsetInBytes, (IntPtr)ptr, sizeInBytes);
+            fixed (T* ptr = &source) UpdateBuffer(buffer, bufferOffsetInBytes, (IntPtr)ptr, sizeInBytes);
         }
 
         /// <summary>

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -672,8 +672,7 @@ namespace Veldrid
             uint bufferOffsetInBytes,
             T source) where T : unmanaged
         {
-            ref byte sourceByteRef = ref Unsafe.AsRef<byte>(Unsafe.AsPointer(ref source));
-            fixed (byte* ptr = &sourceByteRef) UpdateBuffer(buffer, bufferOffsetInBytes, (IntPtr)ptr, (uint)sizeof(T));
+            UpdateBuffer(buffer, bufferOffsetInBytes, (IntPtr)(&source), (uint)sizeof(T));
         }
 
         /// <summary>
@@ -692,8 +691,7 @@ namespace Veldrid
             uint bufferOffsetInBytes,
             ref T source) where T : unmanaged
         {
-            ref byte sourceByteRef = ref Unsafe.AsRef<byte>(Unsafe.AsPointer(ref source));
-            fixed (byte* ptr = &sourceByteRef) UpdateBuffer(buffer, bufferOffsetInBytes, (IntPtr)ptr, (uint)sizeof(T));
+            fixed (T* ptr = &source) UpdateBuffer(buffer, bufferOffsetInBytes, (IntPtr)ptr, (uint)sizeof(T));
         }
 
         /// <summary>
@@ -714,8 +712,7 @@ namespace Veldrid
             ref T source,
             uint sizeInBytes) where T : unmanaged
         {
-            ref byte sourceByteRef = ref Unsafe.AsRef<byte>(Unsafe.AsPointer(ref source));
-            fixed (byte* ptr = &sourceByteRef) UpdateBuffer(buffer, bufferOffsetInBytes, (IntPtr)ptr, sizeInBytes);
+            fixed (T* ptr = &source) UpdateBuffer(buffer, bufferOffsetInBytes, (IntPtr)ptr, sizeInBytes);
         }
 
         /// <summary>


### PR DESCRIPTION
The `Unsafe.AsRef<T>(Unsafe.AsPointer(ref source))` pattern is almost always a bug, and is unfortunately present in a few places in the Veldrid codebase.

`Unsafe.AsPointer` causes a GC-tracked `ref` to lose its GC-tracked status, meaning that if a compacting garbage collection happens to occur before the pointer is converted back into a `ref T` via `Unsafe.AsRef<T>`, the pointer will become stale because the GC was not able to update it to point at the new location of the data. This is known as a GC hole.

In this PR I've removed all instances of the pattern and replaced them with equivalent GC-safe versions.