### PR TITLE
Fix MoltenVK on Apple Silicon

### DIFF
--- a/src/Veldrid/Vk/CommonStrings.cs
+++ b/src/Veldrid/Vk/CommonStrings.cs
@@ -19,5 +19,6 @@
         public static FixedUtf8String Main { get; } = "main";
         public static FixedUtf8String VkKhrGetPhysicalDeviceProperties2 { get; } = "VK_KHR_get_physical_device_properties2";
         public static FixedUtf8String VkKhrPortabilitySubset { get; } = "VK_KHR_portability_subset";
+        public static FixedUtf8String VkKhrPortabilityEnumeration { get; } = "VK_KHR_portability_enumeration";
     }
 }

--- a/src/Veldrid/Vk/VkGraphicsDevice.cs
+++ b/src/Veldrid/Vk/VkGraphicsDevice.cs
@@ -766,6 +766,13 @@ namespace Veldrid.Vk
 
             if (availableInstanceExtensions.Contains(CommonStrings.VkKhrPortabilitySubset)) surfaceExtensions.Add(CommonStrings.VkKhrPortabilitySubset);
 
+            bool hasPortabilityEnumeration = false;
+            if (availableInstanceExtensions.Contains(CommonStrings.VkKhrPortabilityEnumeration))
+            {
+                hasPortabilityEnumeration = true;
+                surfaceExtensions.Add(CommonStrings.VkKhrPortabilityEnumeration);
+            }
+
             if (availableInstanceExtensions.Contains(CommonStrings.VkKhrSurfaceExtensionName)) surfaceExtensions.Add(CommonStrings.VkKhrSurfaceExtensionName);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -838,6 +845,11 @@ namespace Veldrid.Vk
 
             instanceCi.enabledExtensionCount = instanceExtensions.Count;
             instanceCi.ppEnabledExtensionNames = (byte**)instanceExtensions.Data;
+
+            if (hasPortabilityEnumeration && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                // Required for MoltenVK to work on Apple Silicon.
+                instanceCi.flags |= (uint)VkInstanceCreateFlagBits.PortabilityBitKHR;
+            }
 
             instanceCi.enabledLayerCount = instanceLayers.Count;
             if (instanceLayers.Count > 0) instanceCi.ppEnabledLayerNames = (byte**)instanceLayers.Data;


### PR DESCRIPTION
MoltenVK on Apple Silicon requires portability bit to be set in VkInstanceCreateInfo in order to enumerate virtual graphics devices.

Requires https://github.com/ppy/vk/pull/2
See https://github.com/ppy/osu-framework/pull/6590