### PR TITLE
Fixed Point and Anisotropic sampler desc use the wrong standard.

### DIFF
--- a/src/Veldrid/SamplerDescription.cs
+++ b/src/Veldrid/SamplerDescription.cs
@@ -118,9 +118,9 @@ namespace Veldrid
         /// </summary>
         public static readonly SamplerDescription POINT = new SamplerDescription
         {
-            AddressModeU = SamplerAddressMode.Wrap,
-            AddressModeV = SamplerAddressMode.Wrap,
-            AddressModeW = SamplerAddressMode.Wrap,
+            AddressModeU = SamplerAddressMode.Clamp,
+            AddressModeV = SamplerAddressMode.Clamp,
+            AddressModeW = SamplerAddressMode.Clamp,
             Filter = SamplerFilter.MinPointMagPointMipPoint,
             LodBias = 0,
             MinimumLod = 0,
@@ -166,9 +166,9 @@ namespace Veldrid
         /// </summary>
         public static readonly SamplerDescription ANISO4_X = new SamplerDescription
         {
-            AddressModeU = SamplerAddressMode.Wrap,
-            AddressModeV = SamplerAddressMode.Wrap,
-            AddressModeW = SamplerAddressMode.Wrap,
+            AddressModeU = SamplerAddressMode.Clamp,
+            AddressModeV = SamplerAddressMode.Clamp,
+            AddressModeW = SamplerAddressMode.Clamp,
             Filter = SamplerFilter.Anisotropic,
             LodBias = 0,
             MinimumLod = 0,


### PR DESCRIPTION
This PR addresses the issue where the Point and Anisotropic samplers incorrectly use the wrong SamplerAddressMode.
The standard approach should employ `Clamp`.