### PR TITLE
Support tearing in VK swapchain

### DIFF
--- a/src/Veldrid/Vk/VkGraphicsDevice.cs
+++ b/src/Veldrid/Vk/VkGraphicsDevice.cs
@@ -27,6 +27,12 @@ namespace Veldrid.Vk
 
         public override bool IsClipSpaceYInverted => !standardClipYDirection;
 
+        public override bool AllowTearing
+        {
+            get => mainSwapchain.AllowTearing;
+            set => mainSwapchain.AllowTearing = value;
+        }
+
         public override Swapchain MainSwapchain => mainSwapchain;
 
         public override GraphicsDeviceFeatures Features { get; }

--- a/src/Veldrid/Vk/VkSwapchain.cs
+++ b/src/Veldrid/Vk/VkSwapchain.cs
@@ -40,6 +40,22 @@ namespace Veldrid.Vk
             }
         }
 
+        private bool allowTearing;
+
+        public bool AllowTearing
+        {
+            get => allowTearing;
+            set
+            {
+                if (allowTearing == value)
+                    return;
+
+                allowTearing = value;
+
+                recreateAndReacquire(framebuffer.Width, framebuffer.Height);
+            }
+        }
+
         private readonly VkGraphicsDevice gd;
         private readonly VkSwapchainFramebuffer framebuffer;
         private readonly uint presentQueueIndex;
@@ -203,14 +219,15 @@ namespace Veldrid.Vk
 
             if (syncToVBlank)
             {
-                if (presentModes.Contains(VkPresentModeKHR.FifoRelaxedKHR)) presentMode = VkPresentModeKHR.FifoRelaxedKHR;
+                if (presentModes.Contains(VkPresentModeKHR.FifoRelaxedKHR))
+                    presentMode = VkPresentModeKHR.FifoRelaxedKHR;
             }
-            else
-            {
-                if (presentModes.Contains(VkPresentModeKHR.MailboxKHR))
-                    presentMode = VkPresentModeKHR.MailboxKHR;
-                else if (presentModes.Contains(VkPresentModeKHR.ImmediateKHR)) presentMode = VkPresentModeKHR.ImmediateKHR;
-            }
+            else if (allowTearing && presentModes.Contains(VkPresentModeKHR.ImmediateKHR))
+                presentMode = VkPresentModeKHR.ImmediateKHR;
+            else if (presentModes.Contains(VkPresentModeKHR.MailboxKHR))
+                presentMode = VkPresentModeKHR.MailboxKHR;
+            else if (presentModes.Contains(VkPresentModeKHR.ImmediateKHR))
+                presentMode = VkPresentModeKHR.ImmediateKHR;
 
             uint maxImageCount = surfaceCapabilities.maxImageCount == 0 ? uint.MaxValue : surfaceCapabilities.maxImageCount;
             uint imageCount = Math.Min(maxImageCount, surfaceCapabilities.minImageCount + 1);


### PR DESCRIPTION
I'm mostly doing this for exactly one osu! player who I'm in contact with. I do not want to bring any more attention to the Vulkan subsystem (until SDL-GPU where we're likely going to do similar), but they claim this has been useful for them in their own testing (and -- we support it in D3D11 too).

It took me all of 5 minutes to do, so hopefully this can go without much discussion.

Reading material: https://registry.khronos.org/vulkan/specs/latest/man/html/VkPresentModeKHR.html