### PR TITLE
support stencil buffer on GLES, and fix 64bit GL/GLES targets

### DIFF
--- a/src/Veldrid/OpenGL/EGL/EGLNative.cs
+++ b/src/Veldrid/OpenGL/EGL/EGLNative.cs
@@ -12,6 +12,7 @@ namespace Veldrid.OpenGL.EGL
         public const int EGL_BLUE_SIZE = 0x3022;
         public const int EGL_ALPHA_SIZE = 0x3021;
         public const int EGL_DEPTH_SIZE = 0x3025;
+        public const int EGL_STENCIL_SIZE = 0x3026;
         public const int EGL_SURFACE_TYPE = 0x3033;
         public const int EGL_WINDOW_BIT = 0x0004;
         public const int EGL_OPENGL_ES_BIT = 0x0001;
@@ -45,7 +46,7 @@ namespace Veldrid.OpenGL.EGL
         public static extern IntPtr eglGetCurrentDisplay();
 
         [DllImport(lib_name)]
-        public static extern IntPtr eglGetDisplay(int nativeDisplay);
+        public static extern IntPtr eglGetDisplay(IntPtr nativeDisplay);
 
         [DllImport(lib_name)]
         public static extern IntPtr eglGetCurrentSurface(int readdraw);

--- a/src/Veldrid/OpenGL/OpenGLExtensions.cs
+++ b/src/Veldrid/OpenGL/OpenGLExtensions.cs
@@ -33,6 +33,7 @@ namespace Veldrid.OpenGL
         public readonly bool MultiDrawIndirect;
         public readonly bool StorageBuffers;
         public readonly bool AnisotropicFilter;
+        public readonly bool OesPackedDepthStencil;
         private readonly HashSet<string> extensions;
         private readonly GraphicsBackend backend;
         private readonly int major;
@@ -90,6 +91,13 @@ namespace Veldrid.OpenGL
             ArbUniformBufferObject = IsExtensionSupported("GL_ARB_uniform_buffer_object");
 
             AnisotropicFilter = IsExtensionSupported("GL_EXT_texture_filter_anisotropic") || IsExtensionSupported("GL_ARB_texture_filter_anisotropic");
+
+            // D24_UNorm_S8_UInt (GL_DEPTH24_STENCIL8) is core in GL 3.0+ and GLES 3.0+.
+            // On desktop GL 2.x, GL_ARB_framebuffer_object provides it.
+            // On GLES 2.x, it requires the GL_OES_packed_depth_stencil extension.
+            OesPackedDepthStencil = GLVersion(3, 0) || GLESVersion(3, 0)
+                                    || IsExtensionSupported("GL_ARB_framebuffer_object")
+                                    || IsExtensionSupported("GL_OES_packed_depth_stencil");
         }
 
         /// <summary>

--- a/src/Veldrid/OpenGL/OpenGLFormats.cs
+++ b/src/Veldrid/OpenGL/OpenGLFormats.cs
@@ -843,6 +843,11 @@ namespace Veldrid.OpenGL
                 case PixelFormat.R10G10B10A2UNorm:
                     return backend == GraphicsBackend.OpenGL;
 
+                case PixelFormat.D24UNormS8UInt:
+                    return extensions.GLVersion(3, 0) || extensions.GLESVersion(3, 0)
+                           || extensions.IsExtensionSupported("GL_OES_packed_depth_stencil")
+                           || extensions.IsExtensionSupported("GL_ARB_framebuffer_object");
+
                 default:
                     return true;
             }

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -311,6 +311,29 @@ namespace Veldrid.OpenGL
                 case PixelFormat.R32Float:
                     return 32;
 
+                case PixelFormat.D24UNormS8UInt:
+                    return 24;
+
+                case PixelFormat.D32FloatS8UInt:
+                    return 32;
+
+                default:
+                    throw new VeldridException($"Unsupported depth format: {value}");
+            }
+        }
+
+        private static int getStencilBits(PixelFormat value)
+        {
+            switch (value)
+            {
+                case PixelFormat.D24UNormS8UInt:
+                case PixelFormat.D32FloatS8UInt:
+                    return 8;
+
+                case PixelFormat.R16UNorm:
+                case PixelFormat.R32Float:
+                    return 0;
+
                 default:
                     throw new VeldridException($"Unsupported depth format: {value}");
             }
@@ -750,7 +773,7 @@ namespace Veldrid.OpenGL
             IntPtr aNativeWindow,
             SwapchainDescription swapchainDescription)
         {
-            IntPtr display = eglGetDisplay(0);
+            IntPtr display = eglGetDisplay(IntPtr.Zero);
             if (display == IntPtr.Zero) throw new VeldridException($"Failed to get the default Android EGLDisplay: {eglGetError()}");
 
             int major, minor;
@@ -765,6 +788,10 @@ namespace Veldrid.OpenGL
                 EGL_DEPTH_SIZE,
                 swapchainDescription.DepthFormat != null
                     ? getDepthBits(swapchainDescription.DepthFormat.Value)
+                    : 0,
+                EGL_STENCIL_SIZE,
+                swapchainDescription.DepthFormat != null
+                    ? getStencilBits(swapchainDescription.DepthFormat.Value)
                     : 0,
                 EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
                 EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,

--- a/src/Veldrid/OpenGL/OpenGLTexture.cs
+++ b/src/Veldrid/OpenGL/OpenGLTexture.cs
@@ -65,7 +65,15 @@ namespace Veldrid.OpenGL
             Width = description.Width;
             Height = description.Height;
             Depth = description.Depth;
-            Format = description.Format;
+
+            if (description.Format == PixelFormat.D24UNormS8UInt && !gd.Extensions.OesPackedDepthStencil) {
+                Console.WriteLine(
+                    "[Veldrid] GL_OES_packed_depth_stencil not available — downgrading D24_UNorm_S8_UInt to D32_Float_S8_UInt");
+                Format = PixelFormat.D32FloatS8UInt;
+            }
+            else {
+                Format = description.Format;
+            }
             MipLevels = description.MipLevels;
             ArrayLayers = description.ArrayLayers;
             Usage = description.Usage;
@@ -115,7 +123,15 @@ namespace Veldrid.OpenGL
             Width = description.Width;
             Height = description.Height;
             Depth = description.Depth;
-            Format = description.Format;
+
+            if (description.Format == PixelFormat.D24UNormS8UInt && !gd.Extensions.OesPackedDepthStencil) {
+                Console.WriteLine(
+                    "[Veldrid] GL_OES_packed_depth_stencil not available — downgrading D24_UNorm_S8_UInt to D32_Float_S8_UInt");
+                Format = PixelFormat.D32FloatS8UInt;
+            }
+            else {
+                Format = description.Format;
+            }
             MipLevels = description.MipLevels;
             ArrayLayers = description.ArrayLayers;
             Usage = description.Usage;


### PR DESCRIPTION
This code

- adds GLES stencil buffer init (curiously missing entirely), so I can get my SilkyNvg 2d vector draw Veldrid backend running on Android / GLES.
- fixes GL/GLES device setup on 64bit, as eglGetDisplay(int) needs to be eglGetDisplay(IntPtr)  - eglGetDisplay(NativeDisplayType*) 

On GL2/GLES2 where packed stencil (D24UNormS8UInt) is not supported, i decided to automatically fallback (with log message) to D32FloatS8UInt, as Veldrid currently isn't setup to be able to query valid formats before opening, nor does it handle graphics device failure-retry well on EGL. 

In the future i think Veldrid would fit well with more of a WebGPU style capability init, since it's trying to abstract these details... where consumers could start with a profile (Universal - incl GLES/GL2, Standard - DX11/vulkan/metal1+, Extended - raytracing, mesh shaders, etc) and ask for features and preferences with some softness as to how they are satisfiied.





