### PR TITLE
Remove metal display link

### DIFF
--- a/src/Veldrid.MetalBindings/CAMetalLayer.cs
+++ b/src/Veldrid.MetalBindings/CAMetalLayer.cs
@@ -69,6 +69,12 @@ namespace Veldrid.MetalBindings
             set => objc_msgSend(NativePtr, sel_setDisplaySyncEnabled, value);
         }
 
+        public uint maximumDrawableCount
+        {
+            get => uint_objc_msgSend(NativePtr, sel_maximumDrawableCount);
+            set => objc_msgSend(NativePtr, sel_setMaximumDrawableCount, value);
+        }
+
         private static readonly ObjCClass s_class = new ObjCClass(nameof(CAMetalLayer));
         private static readonly Selector sel_device = "device";
         private static readonly Selector sel_setDevice = "setDevice:";
@@ -85,5 +91,7 @@ namespace Veldrid.MetalBindings
         private static readonly Selector sel_displaySyncEnabled = "displaySyncEnabled";
         private static readonly Selector sel_setDisplaySyncEnabled = "setDisplaySyncEnabled:";
         private static readonly Selector sel_nextDrawable = "nextDrawable";
+        private static readonly Selector sel_maximumDrawableCount = "maximumDrawableCount";
+        private static readonly Selector sel_setMaximumDrawableCount = "setMaximumDrawableCount:";
     }
 }

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -67,9 +67,6 @@ namespace Veldrid.MTL
         private readonly IntPtr completionBlockDescriptor;
         private readonly IntPtr completionBlockLiteral;
 
-        private readonly IMtlDisplayLink displayLink;
-        private readonly AutoResetEvent nextFrameReadyEvent;
-        private readonly EventWaitHandle frameEndedEvent = new EventWaitHandle(true, EventResetMode.ManualReset);
         private readonly BackendInfoMetal metalInfo;
         private MTLCommandBuffer latestSubmittedCb;
         private MtlShader unalignedBufferCopyShader;
@@ -124,18 +121,11 @@ namespace Veldrid.MTL
                 libSystem = NativeLibrary.Load("libSystem.dylib");
                 concreteGlobalBlock = NativeLibrary.GetExport(libSystem, "_NSConcreteGlobalBlock");
                 completionHandler = OnCommandBufferCompleted;
-                displayLink = new MtlcvDisplayLink();
             }
             else
             {
                 concreteGlobalBlock = IntPtr.Zero;
                 completionHandler = OnCommandBufferCompleted_Static;
-            }
-
-            if (displayLink != null)
-            {
-                nextFrameReadyEvent = new AutoResetEvent(true);
-                displayLink.Callback += OnDisplayLinkCallback;
             }
 
             completionHandlerFuncPtr = Marshal.GetFunctionPointerForDelegate(completionHandler);
@@ -183,13 +173,10 @@ namespace Veldrid.MTL
 
         public override void UpdateActiveDisplay(int x, int y, int w, int h)
         {
-            displayLink?.UpdateActiveDisplay(x, y, w, h);
         }
 
         public override double GetActualRefreshPeriod()
         {
-            if (displayLink != null) return displayLink.GetActualOutputVideoRefreshPeriod();
-
             return -1.0f;
         }
 
@@ -328,8 +315,6 @@ namespace Veldrid.MTL
 
             Marshal.FreeHGlobal(completionBlockDescriptor);
             Marshal.FreeHGlobal(completionBlockLiteral);
-
-            displayLink?.Dispose();
         }
 
         protected override void UnmapCore(IMappableResource resource, uint subresource)
@@ -393,12 +378,6 @@ namespace Veldrid.MTL
             }
 
             ObjectiveCRuntime.release(cb.NativePtr);
-        }
-
-        private void OnDisplayLinkCallback()
-        {
-            nextFrameReadyEvent.Set();
-            frameEndedEvent.WaitOne();
         }
 
         private MappedResource mapBuffer(MtlBuffer buffer, MapMode mode)
@@ -469,16 +448,7 @@ namespace Veldrid.MTL
 
         private protected override void WaitForNextFrameReadyCore()
         {
-            frameEndedEvent.Reset();
-            nextFrameReadyEvent?.WaitOne(TimeSpan.FromSeconds(1)); // Should never time out.
-
-            // in iOS, if one frame takes longer than the next V-Sync request, the next frame will be processed immediately rather than being delayed to a subsequent V-Sync request,
-            // therefore we will request the next drawable here as a method of waiting until we're ready to draw the next frame.
-            if (!MetalFeatures.IsMacOS)
-            {
-                var mtlSwapchainFramebuffer = Util.AssertSubtype<Framebuffer, MtlSwapchainFramebuffer>(mainSwapchain.Framebuffer);
-                mtlSwapchainFramebuffer.EnsureDrawableAvailable();
-            }
+            mainSwapchain.EnsureDrawableAvailable();
         }
 
         private protected override bool GetPixelFormatSupportCore(
@@ -559,8 +529,6 @@ namespace Veldrid.MTL
 
                 mtlSc.InvalidateDrawable();
             }
-
-            frameEndedEvent.Set();
         }
 
         private protected override void UpdateBufferCore(DeviceBuffer buffer, uint bufferOffsetInBytes, IntPtr source, uint sizeInBytes)

--- a/src/Veldrid/MTL/MTLSwapchain.cs
+++ b/src/Veldrid/MTL/MTLSwapchain.cs
@@ -95,6 +95,7 @@ namespace Veldrid.MTL
             metalLayer.pixelFormat = MtlFormats.VdToMtlPixelFormat(format, false);
             metalLayer.framebufferOnly = true;
             metalLayer.drawableSize = new CGSize(width, height);
+            metalLayer.maximumDrawableCount = 2;
 
             setSyncToVerticalBlank(syncToVerticalBlank);
 

--- a/src/Veldrid/MTL/MTLSwapchain.cs
+++ b/src/Veldrid/MTL/MTLSwapchain.cs
@@ -95,7 +95,9 @@ namespace Veldrid.MTL
             metalLayer.pixelFormat = MtlFormats.VdToMtlPixelFormat(format, false);
             metalLayer.framebufferOnly = true;
             metalLayer.drawableSize = new CGSize(width, height);
-            metalLayer.maximumDrawableCount = 2;
+
+            // Prefer triple buffering on iOS for maximum performance, and double buffering on macOS for minimum latency.
+            metalLayer.maximumDrawableCount = gd.MetalFeatures.IsMacOS ? 2u : 3u;
 
             setSyncToVerticalBlank(syncToVerticalBlank);
 


### PR DESCRIPTION
At some point I'll make a blog post to go through all of my findings, but here is a short(er) version.

First of all I'll say that most of the below is based on my conjecturing or supported by anecdotal evidence. I may not be using the most accurate terms, but there is seldom documentation on this - especially from Apple.

## VBLANK

There are three processes that are important to us: **VBLANK**, **Scanout**, and **Flip**.
- **VBLANK** is a pause duration at the start of the frame before **Scanout**.
- **Scanout** is the duration to transmit data to the screen's internal framebuffer. This is both dependent on cable bandwidth and any internal processing delays of the screen itself.
- **Flip** is the duration for the screen to adjust the colour of every pixel. Historically, CRT screens used this period to irradiate each phosphor for some period of time, but this is almost instantaneous for LCD screens (save for some muxing delays).

Importantly, VBLANK is the only parameter that can be adjusted, and is done so as to meet the physical characteristics of the display panel (e.g. pixel response time) as well delays imposed by Scanout + Flip. There is a particular deadline that the display has to hit, and VBLANK is the mechanism to control that.

For internal displays or displays where high bandwidth is guaranteed, Scanout takes a very short amount of time, and as mentioned above Flip is basically instant. VBLANK _becomes_ the dominating factor and it is now important to remember that it is just an artificial delay imposed by the screen.

Anecdotal testing puts a MacBook's internal ProDisplay at ~5ms VBLANK.

There are two peculiarities with how macOS handles this:
1. You are allowed to render as late as you want during the VBLANK interval. It's possible to get <1 frame latency by delaying your rendering as long as you don't miss the VBlank period - if you miss it then you get shoved into the next Scanout which is up to 2 frames away. That said, it is not easy to do this - macOS provides no mechanism that tells you exactly how long VBLANK is.
2. Metal is locked into a FIFO pipeline that does not provide support for a "mailbox" mechanism. Importantly, this means that the only effect of triple buffering is to delay your frame by one full refresh cycle, which has its use cases but cannot be used as a mechanism to bypass the limitations imposed by VBLANK.

## Display Links

Where do `CADisplayLink`, `CVDisplayLink`, and `CAMetalDisplayLink` fit in all of this? Does it handle this for us?

No.

As far as I can surmise - Apple's docs on this subject are especially poor - display links are simply a VBLANK timer. They callback to your app at the start of one VBLANK and provide a `targetTimestamp` value that appears to indicate the start of the _next_ VBLANK.  
They also perform a second function, which is to control when your app applies backpressure.

### Backpressure

Now for a slight tangent onto backpressure. A typical (Metal) gameplay loop looks like the following:

```
while (running):
    sampleInput();
    update();
    draw():
        METAL_nextDrawable();
        ... (submit rendering commands)
    METAL_presentDrawable();
```

In modern APIs, "swap buffer" doesn't exist. It's an async process that occurs when you call `presentDrawable()` (in Metal). This allows you to push many frames as fast as you want, but eventually your GPU will give up and block your execution at `nextDrawable()`. But in the above loop, this occurs somewhere in the middle of the frame after input has been sampled and would be detrimental to input latency.

The original (removed) code in this PR uses `CVDisplayLink`, but a more fitting construct would be `CAMetalDisplayLink`. It doesn't change much - it's still just a VBLANK timer, but it provides a `CAMetalDrawable` inside its callback. This allows the above loop to be rewritten as:

```
CAMetalDisplayLink.callback = onCallback;

onCallback(drawable):
    sampleInput();
    update();
    draw():
        ... (submit rendering commands)
    METAL_presentDrawable();

while (running):
    sleep(1);
```

It applies backpressure in a way that you're both synchronised to VBLANK and also the GPU's queues are empty for the next frame. It caps the number of in-flight frames to 1.

For osu! this is irrelevant because we already separate our input, update, and draw threads. It would be useful to use this for single threaded execution mode, but the way it is implemented right now is not correct - we really need to run the _entire_ loop through the display link callback rather than blocking at some point inside `DrawFrame()`.

For osu!, there is another mechanism that provides us exactly the same type of backpressure we're attempting to apply here - vsync.

## Changes in this PR

According to the above, this PR applies two changes.

### 1. Remove triple buffering

macOS triple buffers by default. This does nothing for us other than increasing FPS (making numbers bigger), it _does not_ lower input latency - it actually increases it.

### 2. Remove display link

As I hoped to explain above, the display link is only bloating our code without providing any functional benefit.

## Results

The most impactful change is the removal of triple buffering. When vsync is enabled, it will reduce frame latency by around 50-75%. If the scene is fast enough to fit within the VBLANK window, then you will see 1 frame latency when in current builds it incurs a full refresh cycle (2 frames).

This change comes at a cost. FPS will be decreased which means that single threaded execution is impacted. I'd point out again that single threaded execution is not really being done correctly either way. In particular, this may negatively impact iOS devices which run in STE mode [by default](https://github.com/ppy/osu-framework/blob/afc88e863a38564c4539774aadad932f3bb8c844/osu.Framework.iOS/IOSGameHost.cs#L49-L50).

Scenes that have high load, like song select, may miss the VBLANK window and degrade to 60fps on ProMotion displays. Gameplay should run fast enough to meet the VBLANK deadline in general, and experience the most benefit from the reduction in input latency.

I believe in this PR as a stepping stone and that we can work on iOS separately. Either implementing `CAMetalDisplayLink` properly or passing the buffer count through [`SwapchainDescription`](https://github.com/ppy/osu-framework/blob/afc88e863a38564c4539774aadad932f3bb8c844/osu.Framework/Graphics/Veldrid/VeldridDevice.cs#L116-L123) (it doesn't have support for this right now).

## Further work

This PR directly leads to a re-evaluation of the D3D11 pipeline, where we use waitable swapchains in a similar effort to display links expecting that they'll magically reduce input latency to as low as possible. And I'm not being hyperbolic in saying that, when the official documentation [lists them for this purpose](https://learn.microsoft.com/en-us/windows/uwp/gaming/reduce-latency-with-dxgi-1-3-swap-chains).

In reality, waitable swapchain is just a mechanism to introduce backpressure such that the GPU queue is limited to 1 frame at a time.

Furthermore, I mentioned above that you can delay your rendering to as close to the end of the VBLANK period as possible, and that this is not easily doable. This is somewhat untrue because NVIDIA Reflex, AMD Anti-Lag, and Intel XeLL all provide the mechanism to do exactly this.